### PR TITLE
feat: bump compatibility for patches for Youtube to v17.23.35

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/annotation/GeneralAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/annotation/GeneralAdsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/video/annotations/VideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/video/annotations/VideoAdsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/annotation/SeekbarTappingCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/annotation/SeekbarTappingCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/amoled/annotations/AmoledCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/amoled/annotations/AmoledCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/createbutton/annotations/CreateButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/createbutton/annotations/CreateButtonCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", ""17.23.35"")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", ""17.23.35"")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/oldqualitylayout/annotations/OldQualityLayoutCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/oldqualitylayout/annotations/OldQualityLayoutCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/reels/annotations/HideReelsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/reels/annotations/HideReelsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/annotations/ShortsButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/annotations/ShortsButtonCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/integrations/annotations/IntegrationsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/integrations/annotations/IntegrationsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.03.38", "17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.03.38", "17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/manifest/annotations/FixLocaleConfigErrorCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/manifest/annotations/FixLocaleConfigErrorCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/microg/annotations/MicroGPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/microg/annotations/MicroGPatchCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.19.36", "17.20.37", "17.22.36")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.19.36", "17.20.37", "17.22.36", "17.23.35")
     )]
 )
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
Tested the patches on 17.23.35 and they all work fine, so this YouTube version should be added.