### PR TITLE
feat: Enable-Debugging Patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/annotations/EnableDebuggingCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/annotations/EnableDebuggingCompatibility.kt
@@ -1,0 +1,25 @@
+package app.revanced.patches.youtube.misc.enabledebugging.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package(
+        "com.google.android.youtube",
+        arrayOf(
+            "17.14.35",
+            "17.17.34",
+            "17.19.36",
+            "17.20.37",
+            "17.22.36",
+            "17.23.35",
+            "17.23.36",
+            "17.24.34",
+            "17.24.35",
+            "17.25.34"
+        )
+    )]
+)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class EnableDebuggingCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/patch/EnableDebuggingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/patch/EnableDebuggingPatch.kt
@@ -1,0 +1,35 @@
+package app.revanced.patches.youtube.misc.enabledebugging.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.impl.ResourceData
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patcher.patch.impl.ResourcePatch
+import app.revanced.patches.youtube.misc.enabledebugging.annotations.EnableDebuggingCompatibility
+import org.w3c.dom.Element
+
+@Patch(false)
+@Name("enable-debugging")
+@Description("Enable app debugging by patching the manifest file")
+@EnableDebuggingCompatibility
+@Version("0.0.1")
+class EnableDebuggingPatch : ResourcePatch() {
+    override fun execute(data: ResourceData): PatchResult {
+        // create an xml editor instance
+        data.xmlEditor["AndroidManifest.xml"].use { dom ->
+            // get the application node
+            val applicationNode = dom
+                .file
+                .getElementsByTagName("application")
+                .item(0) as Element
+
+            // set application as debuggable
+            applicationNode.setAttribute("android:debuggable", "true")
+        }
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
small patch to set [android:debuggable](https://developer.android.com/guide/topics/manifest/application-element#debug) attribute in manifest. 
This can be useful when developing new patches because it enables the use of some Android studio tools, like
- package filter on logcat
- [Layout Inspector](https://developer.android.com/studio/debug/layout-inspector#layout-inspector)
- Debugging revanced-integrations code (breakpoints and all that good stuff)
- ...


