### PR TITLE
fix: make `hide-shorts-button` fingerprint more future-proof

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/annotations/ShortsButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/annotations/ShortsButtonCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35", "17.23.36", "17.24.34", "17.24.35", "17.25.34", "17.26.35", "17.27.39")
+        "com.google.android.youtube", arrayOf("17.14.35", "17.17.34", "17.19.36", "17.20.37", "17.22.36", "17.23.35", "17.23.36", "17.24.34", "17.24.35", "17.25.34", "17.26.35", "17.27.39", "17.28.34")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/fingerprints/PivotBarButtonsViewFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/fingerprints/PivotBarButtonsViewFingerprint.kt
@@ -3,7 +3,6 @@ package app.revanced.patches.youtube.layout.shorts.button.fingerprints
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.extensions.or
-import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
 import app.revanced.patcher.fingerprint.method.annotation.MatchingMethod
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.youtube.layout.shorts.button.annotations.ShortsButtonCompatibility
@@ -14,7 +13,6 @@ import org.jf.dexlib2.Opcode
 @MatchingMethod(
     "Lknw;", "z"
 )
-@FuzzyPatternScanMethod(2) // FIXME: Test this threshold and find the best value.
 @ShortsButtonCompatibility
 @Version("0.0.1")
 object PivotBarButtonsViewFingerprint : MethodFingerprint(
@@ -22,28 +20,19 @@ object PivotBarButtonsViewFingerprint : MethodFingerprint(
     AccessFlags.PUBLIC or AccessFlags.FINAL,
     listOf("Z"),
     listOf(
-        Opcode.NEW_INSTANCE, // new StateListDrawable()
-        Opcode.INVOKE_DIRECT,
-        Opcode.NEW_ARRAY,
-        Opcode.CONST,
-        Opcode.CONST_16,
-        Opcode.APUT,
-        Opcode.INVOKE_VIRTUAL,
+        Opcode.INVOKE_VIRTUAL_RANGE,
         Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_STATIC,
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
+        Opcode.GOTO,
+        Opcode.IGET_OBJECT,
+        Opcode.IF_NEZ,
         Opcode.SGET_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IGET,
         Opcode.INVOKE_STATIC,
         Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_OBJECT,
-        Opcode.MOVE_OBJECT,
-        Opcode.MOVE,
-        Opcode.MOVE_OBJECT,
-        Opcode.INVOKE_VIRTUAL_RANGE, // pivotBar.getView(drawable, tabName, z, i, map, akebVar, optional)
-        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IF_NEZ,
+        Opcode.SGET_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT,
+        Opcode.IGET
     )
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/patch/ShortsButtonRemoverPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/shorts/button/patch/ShortsButtonRemoverPatch.kt
@@ -35,7 +35,7 @@ class ShortsButtonRemoverPatch : BytecodePatch(
 
         val buttonsViewResult = PivotBarButtonsViewFingerprint.result!!
         val buttonsViewImplementation = buttonsViewResult.mutableMethod.implementation!!
-        val moveViewInstruction = buttonsViewImplementation.instructions[buttonsViewResult.patternScanResult!!.endIndex]
+        val moveViewInstruction = buttonsViewImplementation.instructions[buttonsViewResult.patternScanResult!!.startIndex + 1]
         val viewRegister = (moveViewInstruction as OneRegisterInstruction).registerA
 
 
@@ -48,7 +48,7 @@ class ShortsButtonRemoverPatch : BytecodePatch(
         // Hide the button view via proxy by passing it to the hideShortsButton method
         // It only hides it if the last tab name is "TAB_SHORTS"
         buttonsViewResult.mutableMethod.addInstruction(
-            buttonsViewResult.patternScanResult!!.endIndex + 2,
+            buttonsViewResult.patternScanResult!!.startIndex + 3,
             "invoke-static { v$viewRegister }, Lapp/revanced/integrations/patches/HideShortsButtonPatch;->hideShortsButton(Landroid/view/View;)V"
         )
 


### PR DESCRIPTION
This fixes an error when applying this patch on v17.28.34 (and most likely other future versions) while still working with versions mentioned on the compatibility class.