### PR TITLE
fix: bump youtube music version to 5.16.51

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.apps.youtube.music", arrayOf("5.14.53")
+        "com.google.android.apps.youtube.music", arrayOf("5.14.53", "5.16.51")
     )]
 )
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
not sure if I should make an issue regarding this. but I made a root only build a couple days ago which works fine here 

I included the following patches on version 5.16.51:
INFO: minimized-playback-music succeeded 
INFO: tasteBuilder-remover succeeded 
INFO: hide-get-premium succeeded 
INFO: upgrade-button-remover succeeded 
INFO: background-play succeeded 
INFO: music-video-ads succeeded 
INFO: codecs-unlock succeeded 
INFO: exclusive-audio-playback succeeded 

everything seems to work fine here and I haven't heard any complaints from others.

I used the following versions of the revanced things:
[revanced/revanced-patches: v2.21.3](https://github.com/revanced/revanced-patches/releases/tag/v2.21.3)
[revanced/revanced-integrations: v0.27.6](https://github.com/revanced/revanced-integrations/releases/tag/v0.27.6)
[revanced/revanced-cli: v2.7.1](https://github.com/revanced/revanced-cli/releases/tag/v2.7.1)