### PR TITLE
refactor: do not account for order in `VideoIdPatch.injectCall`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/videoid/patch/VideoIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/videoid/patch/VideoIdPatch.kt
@@ -39,10 +39,11 @@ class VideoIdPatch : BytecodePatch(
     }
 
     companion object {
-        private lateinit var result: MethodFingerprintResult
+        // move-result-object offset
+        private const val offset = 2
         private var videoIdRegister: Int = 0
+        private lateinit var result: MethodFingerprintResult
         private lateinit var insertMethod: MutableMethod
-        private var offset = 2
 
         /**
          * Adds an invoke-static instruction, called with the new id when the video changes
@@ -52,10 +53,9 @@ class VideoIdPatch : BytecodePatch(
             methodDescriptor: String
         ) {
             insertMethod.addInstructions(
-                result.patternScanResult!!.endIndex + offset, // after the move-result-object
+                result.patternScanResult!!.endIndex + offset,
                 "invoke-static {v$videoIdRegister}, $methodDescriptor"
             )
-            offset++ // so additional instructions get added later
         }
     }
 }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/videoid/patch/VideoIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/videoid/patch/VideoIdPatch.kt
@@ -39,8 +39,8 @@ class VideoIdPatch : BytecodePatch(
     }
 
     companion object {
-        // move-result-object offset
-        private const val offset = 2
+        private const val offset = 3 // offset so setCurrentVideoId is called before any injected call
+
         private var videoIdRegister: Int = 0
         private lateinit var result: MethodFingerprintResult
         private lateinit var insertMethod: MutableMethod
@@ -53,7 +53,7 @@ class VideoIdPatch : BytecodePatch(
             methodDescriptor: String
         ) {
             insertMethod.addInstructions(
-                result.patternScanResult!!.endIndex + offset,
+                result.patternScanResult!!.endIndex + offset, // move-result-object offset
                 "invoke-static {v$videoIdRegister}, $methodDescriptor"
             )
         }


### PR DESCRIPTION
## Description

This PR gets rid of the offset when injecting calls. This means that calls will be inserted in reverse order. 

## Motivation

Patches do not depend on each other when they use the VideoId patch as a dependency, hence the order of these calls can be removed. This should be reviewed by @j4k0xb.