### PR TITLE
feat: promo-code-unlock patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ Official patches by ReVanced
 | `general-reddit-ads` | Removes general ads from the Reddit frontpage and subreddits. | all |
 </details>
 
-### 📦 `de.dwd.warnapp`
-<details>
-
-| 💊 Patch | 📜 Description | 🏹 Target Version |
-|:--------:|:--------------:|:-----------------:|
-| `promo-code-unlock` | Disable the validation of promo code, any string will work to unlock all features. | all |
-</details>
-
 ### 📦 `com.google.android.apps.youtube.music`
 <details>
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Official patches by ReVanced
 | `general-reddit-ads` | Removes general ads from the Reddit frontpage and subreddits. | all |
 </details>
 
+### 📦 `de.dwd.warnapp`
+<details>
+
+| 💊 Patch | 📜 Description | 🏹 Target Version |
+|:--------:|:--------------:|:-----------------:|
+| `promo-code-unlock` | Disable the validation of promo code, any string will work to unlock all features. | all |
+</details>
+
 ### 📦 `com.google.android.apps.youtube.music`
 <details>
 

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/annotations/PromoCodeUnlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/annotations/PromoCodeUnlockCompatibility.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.warnwetter.misc.promocode.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package(
+        "de.dwd.warnapp", arrayOf()
+    )]
+)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class PromoCodeUnlockCompatibility

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/fingerprints/PromoCodeUnlockFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/fingerprints/PromoCodeUnlockFingerprint.kt
@@ -2,9 +2,7 @@ package app.revanced.patches.warnwetter.misc.promocode.fingerprints
 
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
-import app.revanced.patcher.extensions.or
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
-import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
 import app.revanced.patcher.fingerprint.method.annotation.MatchingMethod
 import app.revanced.patches.youtube.layout.createbutton.annotations.CreateButtonCompatibility
 import org.jf.dexlib2.AccessFlags
@@ -14,7 +12,6 @@ import org.jf.dexlib2.Opcode
 @MatchingMethod(
     "Lde/dwd/warnapp/model/PromoTokenVerification;", "isValid"
 )
-@FuzzyPatternScanMethod(2) // FIXME: Test this threshold and find the best value.
 @CreateButtonCompatibility
 @Version("0.0.1")
 object PromoCodeUnlockFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/fingerprints/PromoCodeUnlockFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/fingerprints/PromoCodeUnlockFingerprint.kt
@@ -1,0 +1,29 @@
+package app.revanced.patches.warnwetter.misc.promocode.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
+import app.revanced.patcher.fingerprint.method.annotation.MatchingMethod
+import app.revanced.patches.youtube.layout.createbutton.annotations.CreateButtonCompatibility
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+@Name("promo-code-unlock-fingerprint")
+@MatchingMethod(
+    "Lde/dwd/warnapp/model/PromoTokenVerification;", "isValid"
+)
+@FuzzyPatternScanMethod(2) // FIXME: Test this threshold and find the best value.
+@CreateButtonCompatibility
+@Version("0.0.1")
+object PromoCodeUnlockFingerprint : MethodFingerprint(
+    null,
+    null,
+    null,
+    null,
+    null,
+    { methodDef ->
+        methodDef.definingClass.endsWith("PromoTokenVerification;") && methodDef.name == "isValid"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
@@ -27,7 +27,6 @@ class PromoCodeUnlockPatch : BytecodePatch(
 
     override fun execute(data: BytecodeData): PatchResult {
         val method = PromoCodeUnlockFingerprint.result!!.mutableMethod
-        method.removeInstructions(0, method.implementation!!.instructions.size - 1)
         method.addInstructions(
             0,
             """

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.warnwetter.misc.promocode.fingerprints.PromoCodeUnlo
 
 @Patch
 @Name("promo-code-unlock")
-@Description("Disable the validation of promo code, any string will work to unlock all features.")
+@Description("Disables the validation of promo code. Any code will work to unlock all features.")
 @PromoCodeUnlockCompatibility
 @Version("0.0.1")
 class PromoCodeUnlockPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
@@ -1,0 +1,42 @@
+package app.revanced.patches.warnwetter.misc.promocode.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.impl.BytecodeData
+import app.revanced.patcher.extensions.removeInstruction
+import app.revanced.patcher.extensions.removeInstructions
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patcher.patch.impl.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patches.warnwetter.misc.promocode.annotations.PromoCodeUnlockCompatibility
+import app.revanced.patches.warnwetter.misc.promocode.fingerprints.PromoCodeUnlockFingerprint
+
+@Patch
+@Name("promo-code-unlock")
+@Description("Disable the validation of promo code, any string will work to unlock all features.")
+@PromoCodeUnlockCompatibility
+@Version("0.0.1")
+class PromoCodeUnlockPatch : BytecodePatch(
+    listOf(
+        PromoCodeUnlockFingerprint
+    )
+) {
+
+    override fun execute(data: BytecodeData): PatchResult {
+        PromoCodeUnlockFingerprint.result!!.mutableMethod.removeInstructions(0, PromoCodeUnlockFingerprint.result!!.mutableMethod.implementation!!.instructions.size - 1)
+        PromoCodeUnlockFingerprint.result!!.mutableMethod.addInstructions(
+            0,
+            """
+                const/4 v0, 0x1
+                return v0
+            """
+        )
+
+        return PatchResultSuccess()
+    }
+
+
+}

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
@@ -26,8 +26,9 @@ class PromoCodeUnlockPatch : BytecodePatch(
 ) {
 
     override fun execute(data: BytecodeData): PatchResult {
-        PromoCodeUnlockFingerprint.result!!.mutableMethod.removeInstructions(0, PromoCodeUnlockFingerprint.result!!.mutableMethod.implementation!!.instructions.size - 1)
-        PromoCodeUnlockFingerprint.result!!.mutableMethod.addInstructions(
+        val method = PromoCodeUnlockFingerprint.result!!.mutableMethod
+        method.removeInstructions(0, method.implementation!!.instructions.size - 1)
+        method.addInstructions(
             0,
             """
                 const/4 v0, 0x1


### PR DESCRIPTION
This adds a patch for the WarnWetter app, which enables the unlocking of all features via any string in promo code activation field.
I tested it and for it worked for me.

The patch and so on is a bit ugly since this is my first kotlin code and revanced patch. Thanks again to oSumAtrIX and canny.

Screenshot from App..
![asdeasd](https://user-images.githubusercontent.com/49494924/182879554-a05f241d-ae4b-4326-ba63-94504e5f3456.jpg)


