### PR TITLE
fix: WarnWetter failing to register push registration

### DIFF
--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/annotations/FirebaseGetCertPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/annotations/FirebaseGetCertPatchCompatibility.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.warnwetter.misc.firebasegetcert.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package(
+        "de.dwd.warnapp", arrayOf()
+    )]
+)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class FirebaseGetCertPatchCompatibility

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/fingerprints/GetCertMessagingFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/fingerprints/GetCertMessagingFingerprint.kt
@@ -1,0 +1,25 @@
+package app.revanced.patches.warnwetter.misc.firebasegetcert.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.fingerprint.method.annotation.MatchingMethod
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.warnwetter.misc.firebasegetcert.annotations.FirebaseGetCertPatchCompatibility
+
+@Name("messaging-app-certificate-fingerprint")
+@MatchingMethod(
+    "Lcom/google/firebase/installations/remote/c;", "f"
+)
+@FirebaseGetCertPatchCompatibility
+@Version("0.0.1")
+object GetMessagingCertFingerprint : MethodFingerprint(
+    "Ljava/lang/String;",
+    null,
+    null,
+    null,
+    listOf(
+        "ContentValues",
+        "Could not get fingerprint hash for package: ",
+        "No such package: "
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/fingerprints/GetCertRegistrationFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/fingerprints/GetCertRegistrationFingerprint.kt
@@ -1,0 +1,25 @@
+package app.revanced.patches.warnwetter.misc.firebasegetcert.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.fingerprint.method.annotation.MatchingMethod
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.warnwetter.misc.firebasegetcert.annotations.FirebaseGetCertPatchCompatibility
+
+@Name("registration-app-certificate-fingerprint")
+@MatchingMethod(
+    "Lcom/google/firebase/remoteconfig/internal/ConfigFetchHttpClient;", "f"
+)
+@FirebaseGetCertPatchCompatibility
+@Version("0.0.1")
+object GetReqistrationCertFingerprint : MethodFingerprint(
+    "Ljava/lang/String;",
+    null,
+    null,
+    null,
+    listOf(
+        "FirebaseRemoteConfig",
+        "Could not get fingerprint hash for package: ",
+        "No such package: "
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/patch/FirebaseGetCertPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/patch/FirebaseGetCertPatch.kt
@@ -1,0 +1,45 @@
+package app.revanced.patches.warnwetter.misc.firebasegetcert.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.impl.BytecodeData
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.impl.BytecodePatch
+import app.revanced.patches.warnwetter.misc.firebasegetcert.fingerprints.*
+import app.revanced.patches.warnwetter.misc.firebasegetcert.annotations.FirebaseGetCertPatchCompatibility
+
+@Name("spoof-cert-patch")
+@Description("Spoofs the X-Android-Cert header")
+@FirebaseGetCertPatchCompatibility
+@Version("0.0.1")
+class FirebaseGetCertPatch : BytecodePatch(
+    listOf(
+        GetReqistrationCertFingerprint,
+        GetMessagingCertFingerprint
+    )
+) {
+    override fun execute(data: BytecodeData): PatchResult {
+        val spoofedInstruction =
+            """
+                const-string v0, "0799DDF0414D3B3475E88743C91C0676793ED450"
+                return-object v0
+            """
+
+        val registrationCertMethod = GetReqistrationCertFingerprint.result!!.mutableMethod
+        val messagingCertMethod = GetMessagingCertFingerprint.result!!.mutableMethod
+
+        registrationCertMethod.addInstructions(
+            0,
+            spoofedInstruction
+        )
+        messagingCertMethod.addInstructions(
+            0,
+            spoofedInstruction
+        )
+
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/patch/FirebaseGetCertPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/firebasegetcert/patch/FirebaseGetCertPatch.kt
@@ -12,7 +12,7 @@ import app.revanced.patches.warnwetter.misc.firebasegetcert.fingerprints.*
 import app.revanced.patches.warnwetter.misc.firebasegetcert.annotations.FirebaseGetCertPatchCompatibility
 
 @Name("spoof-cert-patch")
-@Description("Spoofs the X-Android-Cert header")
+@Description("Spoofs the X-Android-Cert header.")
 @FirebaseGetCertPatchCompatibility
 @Version("0.0.1")
 class FirebaseGetCertPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/warnwetter/misc/promocode/patch/PromoCodeUnlockPatch.kt
@@ -4,16 +4,21 @@ import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.impl.BytecodeData
-import app.revanced.patcher.extensions.removeInstruction
-import app.revanced.patcher.extensions.removeInstructions
 import app.revanced.patcher.extensions.addInstructions
 import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patcher.patch.impl.BytecodePatch
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.DependsOn
+import app.revanced.patches.warnwetter.misc.firebasegetcert.patch.FirebaseGetCertPatch
 import app.revanced.patches.warnwetter.misc.promocode.annotations.PromoCodeUnlockCompatibility
 import app.revanced.patches.warnwetter.misc.promocode.fingerprints.PromoCodeUnlockFingerprint
 
+@DependsOn(
+    [
+        FirebaseGetCertPatch::class
+    ]
+)
 @Patch
 @Name("promo-code-unlock")
 @Description("Disables the validation of promo code. Any code will work to unlock all features.")


### PR DESCRIPTION
Closes #314, spoofs the `X-Android-Cert` header in order to allow push notifications to be sent to the patched app.