### PR TITLE
feat: bundle dex file into jar file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -31,9 +31,6 @@
         "assets": [
           {
             "path": "build/libs/*.jar"
-          },
-          {
-            "path": "build/libs/*.dex"
           }
         ]
       }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,15 +27,14 @@ dependencies {
 }
 
 tasks {
-    register<DefaultTask>("generateDex") {
-        description = "Generate dex files from build"
+    register<DefaultTask>("generateBundle") {
+        description = "Generate dex files from build and bundle them in the jar file"
         dependsOn(build)
 
         doLast {
             val androidHome = System.getenv("ANDROID_HOME") ?: throw GradleException("ANDROID_HOME not found")
             val d8 = "${androidHome}/build-tools/32.0.0/d8"
             val input = configurations.archives.get().allArtifacts.files.files.first().absolutePath
-            val output = input.replace(".jar", ".dex")
             val work = File("${buildDir}/libs")
 
             exec {
@@ -45,7 +44,7 @@ tasks {
 
             exec {
                 workingDir = work
-                commandLine = listOf("mv", "classes.dex", output)
+                commandLine = listOf("zip", "-u", input, "classes.dex")
             }
         }
     }
@@ -62,6 +61,6 @@ tasks {
     register<DefaultTask>("publish") {
         group = "publish"
         description = "Dummy task"
-        dependsOn(named("generateDex"), named("generateReadme"))
+        dependsOn(named("generateBundle"), named("generateReadme"))
     }
 }


### PR DESCRIPTION
This should work as a cross-platform solution both for desktop and mobile!

It basically inserts the dex file inside the jar file so that it can be used on desktop with the JarPatchBundle (as it is now) and for mobile with the DexPatchBundle. Using only the dex file in mobile was not possible due to missing resources on the dex file.

Merging both is the solution :)

Semantic release file was also updated as after merging this, the jar asset is enough for both platforms.