### PR TITLE
fix: make `custom-branding` cross-platform

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/branding/icon/patch/CustomBrandingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/branding/icon/patch/CustomBrandingPatch.kt
@@ -10,6 +10,7 @@ import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patcher.patch.impl.ResourcePatch
 import app.revanced.patches.youtube.layout.branding.icon.annotations.CustomBrandingCompatibility
 import app.revanced.patches.youtube.misc.manifest.patch.FixLocaleConfigErrorPatch
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -45,9 +46,16 @@ class CustomBrandingPatch : ResourcePatch() {
                 val iconFile = getIconStream("branding/$size/$iconName.png")
                     ?: return PatchResultError("The icon $iconName can not be found.")
 
+                val outputStream = ByteArrayOutputStream()
+                iconFile.use { input ->
+                    outputStream.use { output ->
+                        input.copyTo(output)
+                    }
+                }
+
                 Files.write(
                     resDirectory.resolve("mipmap-$iconDirectory").resolve("$iconName.png").toPath(),
-                    iconFile.readAllBytes()
+                    outputStream.toByteArray()
                 )
             }
         }


### PR DESCRIPTION
InputStream.readAllBytes was only introduced [on Android in API 33](https://developer.android.com/reference/java/io/InputStream#readAllBytes()) so we need an implementation for a wider adoption :)

