### PR TITLE
Fixed syntax issue

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/microg/patch/bytecode/MicroGBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/microg/patch/bytecode/MicroGBytecodePatch.kt
@@ -35,7 +35,7 @@ import org.jf.dexlib2.immutable.reference.ImmutableStringReference
     ]
 )
 @Name("microg-support")
-@Description("Allows YouTube ReVanced to run without root and under a different package name with Vanced MicroG")
+@Description("Allows YouTube ReVanced to run without root and under a different package name with Vanced MicroG.")
 @MicroGPatchCompatibility
 @Version("0.0.1")
 class MicroGBytecodePatch : BytecodePatch(


### PR DESCRIPTION
Fixed syntax issue in order to make use of regex patterns.

I made a GUI [ReVanced Patcher](https://github.com/iklevente/ReVanced-Sharper) that can dynamically add apps and patches so I need to make use of the revanced-patches readme.md document.
It's a great way to group apps together by patches and version compatibility so it would be nice to see to follow the generated syntaxes everywhere.