### PR TITLE
chore: remove ReVanced from YouTube Music label as the name is too long already

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
@@ -2,6 +2,6 @@ package app.revanced.patches.music.misc.microg.shared
 
 object Constants {
     internal const val BASE_MICROG_PACKAGE_NAME = "com.mgoogle"
-    internal const val REVANCED_MUSIC_APP_NAME = "YouTube Music ReVanced"
+    internal const val REVANCED_MUSIC_APP_NAME = "YouTube Music"
     internal const val REVANCED_MUSIC_PACKAGE_NAME = "app.revanced.android.apps.youtube.music"
 }


### PR DESCRIPTION
remove ReVanced from YouTube Music as the name is too long already