### PR TITLE
feat: Rename YT Music

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
@@ -2,6 +2,6 @@ package app.revanced.patches.music.misc.microg.shared
 
 object Constants {
     internal const val BASE_MICROG_PACKAGE_NAME = "com.mgoogle"
-    internal const val REVANCED_MUSIC_APP_NAME = "YouTube Music ReVanced"
+    internal const val REVANCED_MUSIC_APP_NAME = "YT Music ReVanced"
     internal const val REVANCED_MUSIC_PACKAGE_NAME = "app.revanced.android.apps.youtube.music"
 }


### PR DESCRIPTION
The current name is too long. This PR aims to fix it just like the official YT Music app does.