### PR TITLE
fix(YouTube/theme): amoled contextual menus

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/patch/ThemePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/patch/ThemePatch.kt
@@ -30,7 +30,8 @@ class ThemePatch : ResourcePatch {
 
                 node.textContent = when (node.getAttribute("name")) {
                     "yt_black1", "yt_black1_opacity95", "yt_black1_opacity98", "yt_black2", "yt_black3", "yt_black4",
-                    "yt_status_bar_background_dark" -> darkThemeBackgroundColor
+                    "yt_status_bar_background_dark", "material_grey_100", "material_grey_50", "material_grey_600",
+                    "material_grey_800", "material_grey_850", "material_grey_900", "material_grey_white_1000" -> darkThemeBackgroundColor
 
                     "yt_white1", "yt_white1_opacity95", "yt_white1_opacity98", "yt_white2", "yt_white3",
                     "yt_white4" -> lightThemeBackgroundColor


### PR DESCRIPTION
This patch is useful to apply Amoled tint to some contextual menus (for example: the one that contains the button, to open the advanced search filters).