### PR TITLE
feat: change patched YouTube name

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/microg/shared/Constants.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/microg/shared/Constants.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.youtube.misc.microg.shared
 
 object Constants {
-    internal const val REVANCED_APP_NAME = "YouTube ReVanced"
+    internal const val REVANCED_APP_NAME = "ReVanced"
     internal const val REVANCED_PACKAGE_NAME = "app.revanced.android.youtube"
     internal const val PACKAGE_NAME = "com.google.android.youtube"
     internal const val SPOOFED_PACKAGE_NAME = PACKAGE_NAME


### PR DESCRIPTION
This changes the default YouTube name to be more compact, and more importantly, actually fit into the launcher. Similar to #977, but for YouTube