### PR TITLE
feat(ticktick): unlock all themes

### DIFF
--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/annotations/UnlockThemesCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/annotations/UnlockThemesCompatibility.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.ticktick.misc.themeunlock.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("com.ticktick.task")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class UnlockThemesCompatibility

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/CheckLockedThemesFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/CheckLockedThemesFingerprint.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
 
-@Name("check-locked-theme")
+@Name("check-locked-theme-fingerprint")
 @UnlockThemesCompatibility
 @Version("0.0.1")
 object CheckLockedThemesFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/CheckLockedThemesFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/CheckLockedThemesFingerprint.kt
@@ -1,0 +1,15 @@
+package app.revanced.patches.ticktick.misc.themeunlock.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
+
+@Name("check-locked-theme")
+@UnlockThemesCompatibility
+@Version("0.0.1")
+object CheckLockedThemesFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("Theme;") && methodDef.name == "isLockedTheme"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/ProThemesFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/ProThemesFingerprint.kt
@@ -1,0 +1,15 @@
+package app.revanced.patches.ticktick.misc.themeunlock.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
+
+@Name("set-theme")
+@UnlockThemesCompatibility
+@Version("0.0.1")
+object ProThemesFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("ThemePreviewActivity;") && methodDef.name == "lambda\$updateUserBtn\$1"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/SetThemeFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/SetThemeFingerprint.kt
@@ -5,10 +5,10 @@ import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
 
-@Name("set-theme")
+@Name("set-theme-fingerprint")
 @UnlockThemesCompatibility
 @Version("0.0.1")
-object ProThemesFingerprint : MethodFingerprint(
+object SetThemeFingerprint : MethodFingerprint(
     customFingerprint = { methodDef ->
         methodDef.definingClass.endsWith("ThemePreviewActivity;") && methodDef.name == "lambda\$updateUserBtn\$1"
     }

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
@@ -12,7 +12,7 @@ import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
 import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.CheckLockedThemesFingerprint
-import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.ProThemesFingerprint
+import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.SetThemeFingerprint
 
 @Patch
 @Name("unlock-themes")
@@ -22,7 +22,7 @@ import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.ProThemesFing
 class UnlockProPatch : BytecodePatch(
     listOf(
         CheckLockedThemesFingerprint,
-        ProThemesFingerprint
+        SetThemeFingerprint
     )
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
@@ -35,8 +35,8 @@ class UnlockProPatch : BytecodePatch(
             """
         )
         
-        val proThemesMethod = ProThemesFingerprint.result!!.mutableMethod
-        proThemesMethod.removeInstructions(0, 9)
+        val setThemeMethod = SetThemeFingerprint.result!!.mutableMethod
+        setThemeMethod.removeInstructions(0, 9)
         
         return PatchResultSuccess()
     }

--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
@@ -1,0 +1,43 @@
+package app.revanced.patches.ticktick.misc.themeunlock.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.extensions.removeInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.ticktick.misc.themeunlock.annotations.UnlockThemesCompatibility
+import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.CheckLockedThemesFingerprint
+import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.ProThemesFingerprint
+
+@Patch
+@Name("unlock-themes")
+@Description("Unlocks all themes.")
+@UnlockThemesCompatibility
+@Version("0.0.1")
+class UnlockProPatch : BytecodePatch(
+    listOf(
+        CheckLockedThemesFingerprint,
+        ProThemesFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        val lockedThemesMethod = CheckLockedThemesFingerprint.result!!.mutableMethod
+        lockedThemesMethod.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """
+        )
+        
+        val proThemesMethod = ProThemesFingerprint.result!!.mutableMethod
+        proThemesMethod.removeInstructions(0, 9)
+        
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
This removes the requirements from the themes in [TickTick](https://play.google.com/store/apps/details?id=com.ticktick.task).
Themes can either be locked to require a certain amount of achievements, which is removed by the [CheckLockedThemesFingerprint](src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/CheckLockedThemesFingerprint.kt), or require the user to have a premium account (fixed by the [ProThemesFingerprint](src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/fingerprints/ProThemesFingerprint.kt)).