### PR TITLE
feat(twitch/debug-mode): Enables Twitch's internal debugging mode

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/debug/annotations/DebugModeCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/annotations/DebugModeCompatibility.kt
@@ -1,0 +1,10 @@
+package app.revanced.patches.twitch.debug.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("tv.twitch.android.app")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class DebugModeCompatibility
+

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsDebugConfigEnabledFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsDebugConfigEnabledFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.debug.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
+
+@Name("is-debug-config-enabled-fingerprint")
+
+@DebugModeCompatibility
+@Version("0.0.1")
+object IsDebugConfigEnabledFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("BuildConfigUtil;") && methodDef.name == "isDebugConfigEnabled"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsDebugConfigEnabledFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsDebugConfigEnabledFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
 
 @Name("is-debug-config-enabled-fingerprint")
-
 @DebugModeCompatibility
 @Version("0.0.1")
 object IsDebugConfigEnabledFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsOmVerificationEnabledFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsOmVerificationEnabledFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.debug.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
+
+@Name("is-om-verification-enabled-fingerprint")
+
+@DebugModeCompatibility
+@Version("0.0.1")
+object IsOmVerificationEnabledFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("BuildConfigUtil;") && methodDef.name == "isOmVerificationEnabled"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsOmVerificationEnabledFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/IsOmVerificationEnabledFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
 
 @Name("is-om-verification-enabled-fingerprint")
-
 @DebugModeCompatibility
 @Version("0.0.1")
 object IsOmVerificationEnabledFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/ShouldShowDebugOptionsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/ShouldShowDebugOptionsFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
 
 @Name("should-show-debug-options-fingerprint")
-
 @DebugModeCompatibility
 @Version("0.0.1")
 object ShouldShowDebugOptionsFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/ShouldShowDebugOptionsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/fingerprints/ShouldShowDebugOptionsFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.debug.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
+
+@Name("should-show-debug-options-fingerprint")
+
+@DebugModeCompatibility
+@Version("0.0.1")
+object ShouldShowDebugOptionsFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("BuildConfigUtil;") && methodDef.name == "shouldShowDebugOptions"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.twitch.debug.fingerprints.IsDebugConfigEnabledFinger
 import app.revanced.patches.twitch.debug.fingerprints.IsOmVerificationEnabledFingerprint
 import app.revanced.patches.twitch.debug.fingerprints.ShouldShowDebugOptionsFingerprint
 
-@Patch(include=false)
+@Patch(false)
 @Name("debug-mode")
 @Description("Enables Twitch's internal debugging mode.")
 @DebugModeCompatibility

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
@@ -1,0 +1,49 @@
+package app.revanced.patches.twitch.debug.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.twitch.debug.annotations.DebugModeCompatibility
+import app.revanced.patches.twitch.debug.fingerprints.IsDebugConfigEnabledFingerprint
+import app.revanced.patches.twitch.debug.fingerprints.IsOmVerificationEnabledFingerprint
+import app.revanced.patches.twitch.debug.fingerprints.ShouldShowDebugOptionsFingerprint
+
+@Patch(include=false)
+@Name("twitch-debug-mode")
+@Description("Enables Twitch's internal debugging mode.")
+@DebugModeCompatibility
+@Version("0.0.1")
+class DebugModePatch : BytecodePatch(
+    listOf(
+        IsDebugConfigEnabledFingerprint,
+        IsOmVerificationEnabledFingerprint,
+        ShouldShowDebugOptionsFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        listOf(
+            IsDebugConfigEnabledFingerprint,
+            IsOmVerificationEnabledFingerprint,
+            ShouldShowDebugOptionsFingerprint
+        ).forEach {
+            with(it.result!!) {
+                with(mutableMethod) {
+                    addInstructions(
+                        0,
+                        """
+                             const/4 v0, 0x1
+                             return v0
+                          """
+                    )
+                }
+            }
+        }
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/debug/patch/DebugModePatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.twitch.debug.fingerprints.IsOmVerificationEnabledFin
 import app.revanced.patches.twitch.debug.fingerprints.ShouldShowDebugOptionsFingerprint
 
 @Patch(include=false)
-@Name("twitch-debug-mode")
+@Name("debug-mode")
 @Description("Enables Twitch's internal debugging mode.")
 @DebugModeCompatibility
 @Version("0.0.1")


### PR DESCRIPTION
This patch unlocks a hidden debug mode in the Twitch app. The patch is excluded by default (just like the `enable-debugging` patch for YouTube).

It enables UI testing (inject fake comments, for example), web API testing (verbose GraphQL logging), a crash handler with an on-screen stack-trace display, and some more stuff.

This debug mode is very helpful while creating and debugging patches for Twitch.