### PR TITLE
feat(twitch/block-video-ads): Blocks video ads in streams and VODs (experimental)

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/annotations/VideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/annotations/VideoAdsCompatibility.kt
@@ -1,0 +1,10 @@
+package app.revanced.patches.twitch.ad.video.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("tv.twitch.android.app")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class VideoAdsCompatibility
+

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 
 @Name("ads-manager-play-fingerprint")
-
 @VideoAdsCompatibility
 @Version("0.0.1")
 object AdsManagerFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
@@ -4,11 +4,11 @@ import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
-import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 
 @Name("ads-manager-play-fingerprint")
 
-@AudioAdsCompatibility
+@VideoAdsCompatibility
 @Version("0.0.1")
 object AdsManagerFingerprint : MethodFingerprint(
     customFingerprint = { method ->

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/AdsManagerFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.ad.video.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+
+@Name("ads-manager-play-fingerprint")
+
+@AudioAdsCompatibility
+@Version("0.0.1")
+object AdsManagerFingerprint : MethodFingerprint(
+    customFingerprint = { method ->
+        method.definingClass.endsWith("AdsManagerImpl;") && method.name == "playAds"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
@@ -9,17 +9,12 @@ import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 import org.jf.dexlib2.AccessFlags
 
 @Name("check-ad-eligibility-fingerprint")
-
 @VideoAdsCompatibility
 @Version("0.0.1")
 object CheckAdEligibilityLambdaFingerprint : MethodFingerprint(
-    "Lio/reactivex/SingleSource;",
+    "L",
     AccessFlags.PRIVATE or AccessFlags.FINAL or AccessFlags.STATIC,
-    listOf(
-        "Ltv/twitch/android/shared/ads/models/AdRequestInfo;",
-        "Ltv/twitch/android/shared/ads/eligibility/AdEligibilityFetcher;",
-        "Ltv/twitch/android/util/Optional;"
-    ),
+    listOf("L", "L", "L"),
     customFingerprint = { method ->
         method.definingClass.endsWith("AdEligibilityFetcher;") &&
                 method.name.contains("shouldRequestAd")

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
@@ -1,0 +1,27 @@
+package app.revanced.patches.twitch.ad.video.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.extensions.or
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+import org.jf.dexlib2.AccessFlags
+
+@Name("check-ad-eligibility-fingerprint")
+
+@AudioAdsCompatibility
+@Version("0.0.1")
+object CheckAdEligibilityLambdaFingerprint : MethodFingerprint(
+    "Lio/reactivex/SingleSource;",
+    AccessFlags.PRIVATE or AccessFlags.FINAL or AccessFlags.STATIC,
+    listOf(
+        "Ltv/twitch/android/shared/ads/models/AdRequestInfo;",
+        "Ltv/twitch/android/shared/ads/eligibility/AdEligibilityFetcher;",
+        "Ltv/twitch/android/util/Optional;"
+    ),
+    customFingerprint = { method ->
+        method.definingClass.endsWith("AdEligibilityFetcher;") &&
+                method.name.contains("shouldRequestAd")
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/CheckAdEligibilityLambdaFingerprint.kt
@@ -5,12 +5,12 @@ import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.extensions.or
 
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
-import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 import org.jf.dexlib2.AccessFlags
 
 @Name("check-ad-eligibility-fingerprint")
 
-@AudioAdsCompatibility
+@VideoAdsCompatibility
 @Version("0.0.1")
 object CheckAdEligibilityLambdaFingerprint : MethodFingerprint(
     "Lio/reactivex/SingleSource;",

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
@@ -4,11 +4,11 @@ import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
-import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 
 @Name("content-config-show-ads-fingerprint")
 
-@AudioAdsCompatibility
+@VideoAdsCompatibility
 @Version("0.0.1")
 object ContentConfigShowAdsFingerprint : MethodFingerprint(
     customFingerprint = { method ->

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
 
 @Name("content-config-show-ads-fingerprint")
-
 @VideoAdsCompatibility
 @Version("0.0.1")
 object ContentConfigShowAdsFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/fingerprints/ContentConfigShowAdsFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.ad.video.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+
+@Name("content-config-show-ads-fingerprint")
+
+@AudioAdsCompatibility
+@Version("0.0.1")
+object ContentConfigShowAdsFingerprint : MethodFingerprint(
+    customFingerprint = { method ->
+        method.definingClass.endsWith("ContentConfigData;") && method.name == "getShowAds"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/patch/VideoAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/patch/VideoAdsPatch.kt
@@ -1,0 +1,60 @@
+package app.revanced.patches.twitch.ad.video.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.twitch.ad.video.annotations.VideoAdsCompatibility
+import app.revanced.patches.twitch.ad.video.fingerprints.AdsManagerFingerprint
+import app.revanced.patches.twitch.ad.video.fingerprints.CheckAdEligibilityLambdaFingerprint
+import app.revanced.patches.twitch.ad.video.fingerprints.ContentConfigShowAdsFingerprint
+
+@Patch
+@Name("block-video-ads")
+@Description("Blocks video ads in streams and VODs.")
+@VideoAdsCompatibility
+@Version("0.0.1")
+class VideoAdsPatch : BytecodePatch(
+    listOf(
+        ContentConfigShowAdsFingerprint,
+        AdsManagerFingerprint,
+        CheckAdEligibilityLambdaFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        // Pretend our player is ineligible for all ads
+        with(CheckAdEligibilityLambdaFingerprint.result!!) {
+            mutableMethod.addInstructions(
+                0,
+                """
+                    const/4 v0, 0
+                    invoke-static {v0}, Lio/reactivex/Single;->just(Ljava/lang/Object;)Lio/reactivex/Single;
+                    move-result-object p0
+                    return-object p0
+                """
+            )
+        }
+
+        // Spoof showAds JSON field
+        with(ContentConfigShowAdsFingerprint.result!!) {
+            mutableMethod.addInstructions(0, """
+                    const/4 v0, 0
+                    return v0
+                """
+            )
+        }
+
+        // Block playAds call
+        with(AdsManagerFingerprint.result!!) {
+            mutableMethod.addInstruction(0, "return-void")
+        }
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
This patch should (hopefully) block (most) video ads in the Twitch app.

So far, this patch works reliably for me; however, the Twitch app has a massive amount of ad-related code, so I don't want to guarantee a 100% ad block rate. 

The app also contains code to handle ads that are embedded directly into the video stream. I didn't encounter embedded ads anywhere, and I doubt they are currently used; however, this patch won't be able to handle them if they suddenly start popping up. 