### PR TITLE
feat(twitch/block-audio-ads): Blocks audio ads in streams and VODs

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/annotations/AudioAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/annotations/AudioAdsCompatibility.kt
@@ -1,0 +1,10 @@
+package app.revanced.patches.twitch.ad.audio.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("tv.twitch.android.app")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class AudioAdsCompatibility
+

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/fingerprints/AudioAdsPresenterPlayFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/fingerprints/AudioAdsPresenterPlayFingerprint.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
 
 @Name("audio-ads-presenter-play-fingerprint")
-
 @AudioAdsCompatibility
 @Version("0.0.1")
 object AudioAdsPresenterPlayFingerprint : MethodFingerprint(

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/fingerprints/AudioAdsPresenterPlayFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/fingerprints/AudioAdsPresenterPlayFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitch.ad.audio.fingerprints
+
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+
+@Name("audio-ads-presenter-play-fingerprint")
+
+@AudioAdsCompatibility
+@Version("0.0.1")
+object AudioAdsPresenterPlayFingerprint : MethodFingerprint(
+    customFingerprint = { method ->
+        method.definingClass.endsWith("AudioAdsPlayerPresenter;") && method.name == "playAd"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/patch/AudioAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/patch/AudioAdsPatch.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.twitch.ad.audio.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.twitch.ad.audio.annotations.AudioAdsCompatibility
+import app.revanced.patches.twitch.ad.audio.fingerprints.AudioAdsPresenterPlayFingerprint
+
+@Patch
+@Name("block-audio-ads")
+@Description("Blocks audio ads in streams and VODs.")
+@AudioAdsCompatibility
+@Version("0.0.1")
+class AudioAdsPatch : BytecodePatch(
+    listOf(AudioAdsPresenterPlayFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        // Block playAds call
+        with(AudioAdsPresenterPlayFingerprint.result!!) {
+            mutableMethod.addInstruction(0, "return-void")
+        }
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
This patch blocks [audio ads](https://help.twitch.tv/s/article/audio-ads?language=en_US) in the Twitch app (= stream is visible, but an ad takes over the audio).

I didn't even know these ads existed until I went through the decompilation, but luckily, Twitch's debug mode had the option to force show them in every stream so that I could test my blocking method properly.