### PR TITLE
fix(tiktok/settings): tiktok's settings patch name make 'revanced manager' confuse with youtube settings patch name

### DIFF
--- a/src/main/kotlin/app/revanced/patches/tiktok/misc/settings/patch/TikTokSettingsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tiktok/misc/settings/patch/TikTokSettingsPatch.kt
@@ -28,7 +28,7 @@ import org.jf.dexlib2.iface.reference.TypeReference
 
 @Patch
 @DependsOn([TikTokIntegrationsPatch::class])
-@Name("settings")
+@Name("tiktok-settings")
 @Description("Adds settings for ReVanced to TikTok.")
 @TikTokSettingsCompatibility
 @Version("0.0.1")


### PR DESCRIPTION
https://discord.com/channels/952946952348270622/1044056142864711751