### PR TITLE
feat(anytracker): `unlock-premium` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/annotations/UnlockPremiumCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/annotations/UnlockPremiumCompatibility.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.anytracker.misc.premium.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("com.shervinkoushan.anyTracker")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class UnlockPremiumCompatibility

--- a/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/fingerprints/IsPurchasedFlowFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/fingerprints/IsPurchasedFlowFingerprint.kt
@@ -6,15 +6,6 @@ import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.Opcode
 
 object IsPurchasedFlowFingerprint : MethodFingerprint(
-    access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
-    customFingerprint = { methodDef ->
-        methodDef.definingClass.contains("BillingDataSource\$") &&
-                methodDef.parameterTypes.size == 1 &&
-                methodDef.parameterTypes.first().endsWith("Flow;")
-    },
-    opcodes = listOf(
-        Opcode.IPUT_OBJECT,
-        Opcode.INVOKE_DIRECT,
-        Opcode.RETURN_VOID
-    )
+    "Landroidx/lifecycle/LiveData"
+    strings = listOf("premium_user", "sku"),
 )

--- a/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/fingerprints/IsPurchasedFlowFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/fingerprints/IsPurchasedFlowFingerprint.kt
@@ -1,0 +1,20 @@
+package app.revanced.patches.anytracker.misc.premium.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object IsPurchasedFlowFingerprint : MethodFingerprint(
+    access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.contains("BillingDataSource\$") &&
+                methodDef.parameterTypes.size == 1 &&
+                methodDef.parameterTypes.first().endsWith("Flow;")
+    },
+    opcodes = listOf(
+        Opcode.IPUT_OBJECT,
+        Opcode.INVOKE_DIRECT,
+        Opcode.RETURN_VOID
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/patch/UnlockPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/patch/UnlockPremiumPatch.kt
@@ -1,0 +1,40 @@
+package app.revanced.patches.anytracker.misc.premium.patch
+
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.anytracker.misc.premium.annotations.UnlockPremiumCompatibility
+import app.revanced.patches.anytracker.misc.premium.fingerprints.IsPurchasedFlowFingerprint
+
+@Patch
+@Name("unlock-premium")
+@Description("Unlocks all premium features.")
+@UnlockPremiumCompatibility
+@Version("0.0.1")
+class UnlockPremiumPatch : BytecodePatch(
+    listOf(
+        IsPurchasedFlowFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        val method = IsPurchasedFlowFingerprint.result!!.mutableMethod
+        method.addInstructions(
+            0,
+            """
+                const/4 p1, 0x1
+                invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+                move-result-object p1
+                invoke-static {p1}, Lkotlinx/coroutines/flow/FlowKt;->flowOf(Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+            """
+        )
+
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/patch/UnlockPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/anytracker/misc/premium/patch/UnlockPremiumPatch.kt
@@ -28,10 +28,18 @@ class UnlockPremiumPatch : BytecodePatch(
         method.addInstructions(
             0,
             """
-                const/4 p1, 0x1
-                invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
-                move-result-object p1
-                invoke-static {p1}, Lkotlinx/coroutines/flow/FlowKt;->flowOf(Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+            	const/4 v0, 0x1
+            	invoke-static {v0}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+            	move-result-object v0
+            	invoke-static {v0}, Lkotlinx/coroutines/flow/FlowKt;->flowOf(Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+            	move-result-object v1
+            	const/4 v2, 0x0
+            	const-wide/16 v3, 0x0
+            	const/4 v5, 0x3
+            	const/4 v6, 0x0
+            	invoke-static/range {v1 .. v6}, Landroidx/lifecycle/FlowLiveDataConversions;->asLiveData${'$'}default(Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;JILjava/lang/Object;)Landroidx/lifecycle/LiveData;
+            	move-result-object v0
+            	return-object v0
             """
         )
 


### PR DESCRIPTION
## About

Adds back `unlock-premium` patch.

RE: https://github.com/revanced/revanced-patches/pull/1094


## Issue until opening the pull request

After patching, signing the apk is not possible anymore:

```
com.android.apksig.apk.ApkFormatException: Malformed ZIP entry: LICENSE_OFL
	at com.android.apksig.ApkSigner.sign(ApkSigner.java:359)
	at com.android.apksig.ApkSigner.sign(ApkSigner.java:204)
	at app.revanced.utils.signing.Signer.signApk(Signer.kt:77)
	at app.revanced.cli.signing.Signing.sign(Signing.kt:10)
	at app.revanced.cli.command.MainCommand.run(MainCommand.kt:168)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2026)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at app.revanced.cli.main.MainKt.main(Main.kt:7)
Caused by: com.android.apksig.zip.ZipFormatException: CRC-32 mismatch between Local File Header and Central Directory for entry LICENSE_OFL. LFH: 4005374435, CD: 2307069120
	at com.android.apksig.internal.zip.LocalFileRecord.getRecord(LocalFileRecord.java:191)
	at com.android.apksig.internal.zip.LocalFileRecord.getRecord(LocalFileRecord.java:127)
	at com.android.apksig.ApkSigner.sign(ApkSigner.java:356)
	... 13 more
```