### PR TITLE
refactor(youtube/vertical-scroll-patch): patch canScrollVertically() …

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
@@ -8,12 +8,6 @@ object CanScrollVerticallyFingerprint : MethodFingerprint(
     "Z",
     parameters = emptyList(),
     opcodes = listOf(
-        Opcode.IGET_OBJECT,
-        Opcode.INSTANCE_OF,
-        Opcode.CONST_4,
-        Opcode.IF_EQZ,
-        Opcode.CHECK_CAST,
-        Opcode.INVOKE_STATIC,
         Opcode.MOVE_RESULT,
         Opcode.RETURN,
         Opcode.INVOKE_VIRTUAL,

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
@@ -7,6 +7,17 @@ import org.jf.dexlib2.Opcode
 object CanScrollVerticallyFingerprint : MethodFingerprint(
     "Z",
     parameters = emptyList(),
-    opcodes = listOf(Opcode.INSTANCE_OF),
+    opcodes = listOf(
+        Opcode.IGET_OBJECT,
+        Opcode.INSTANCE_OF,
+        Opcode.CONST_4,
+        Opcode.IF_EQZ,
+        Opcode.CHECK_CAST,
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT,
+        Opcode.RETURN,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+    ),
     customFingerprint = { methodDef -> methodDef.definingClass.endsWith("SwipeRefreshLayout;") }
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
@@ -8,8 +8,6 @@ object CanScrollVerticallyFingerprint : MethodFingerprint(
     "Z",
     parameters = emptyList(),
     opcodes = listOf(
-        Opcode.MOVE_RESULT,
-        Opcode.RETURN,
         Opcode.INVOKE_VIRTUAL,
         Opcode.MOVE_RESULT,
     ),

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/patch/VerticalScrollPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/patch/VerticalScrollPatch.kt
@@ -4,12 +4,14 @@ import app.revanced.extensions.toErrorResult
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.BytecodeContext
-import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.extensions.instruction
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patches.youtube.misc.fix.verticalscroll.annotations.VerticalScrollCompatibility
 import app.revanced.patches.youtube.misc.fix.verticalscroll.fingerprints.CanScrollVerticallyFingerprint
+import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Description("Fixes issues with scrolling on the home screen when the first component is of type EmptyComponent.")
 @VerticalScrollCompatibility
@@ -20,13 +22,17 @@ class VerticalScrollPatch : BytecodePatch(
     override fun execute(context: BytecodeContext): PatchResult {
         val result = CanScrollVerticallyFingerprint.result ?: return CanScrollVerticallyFingerprint.toErrorResult()
 
-        result.mutableMethod.addInstructions(
-            0,
-            """
-                const/4 v0, 0x0
-                return v0
-            """
-        )
+        with(result) {
+            val method = mutableMethod
+
+            val moveResultIndex = scanResult.patternScanResult!!.endIndex
+            val moveResultRegister = (method.instruction(moveResultIndex) as OneRegisterInstruction).registerA
+
+            method.addInstruction(
+                moveResultIndex + 1,
+                "const/4 v$moveResultRegister, 0x0"
+            )
+        }
 
         return PatchResultSuccess()
     }


### PR DESCRIPTION
…only

It's pointless to patch the entire method to return a false value. Only ```canScrollVertically()``` method should be patched instead, so as to leave the ```if(view instanceof ListView)``` condition untouched (which could be useful to prevent bugs of the swipe to reload gesture).