### PR TITLE
fix(youtube/BottomControls): wrong `nameSpaceLength`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/playercontrols/resource/patch/BottomControlsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/playercontrols/resource/patch/BottomControlsResourcePatch.kt
@@ -68,7 +68,7 @@ class BottomControlsResourcePatch : ResourcePatch {
                     "$namespace/$lastLeftOf"
 
                 // set lastLeftOf attribute to the the current element
-                val nameSpaceLength = 4
+                val nameSpaceLength = 5
                 lastLeftOf = element.attributes.getNamedItem("android:id").nodeValue.substring(nameSpaceLength)
 
                 // copy the element


### PR DESCRIPTION
This caused an error when compiling resources with multiple bottom control button patches, but probably not noticed since only downloads patch was using this.
Current code returns: `/some_id`, when it should return `some_id`.