### PR TITLE
fix(youtube/vertical-scroll): wrong fingerprint

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/verticalscroll/fingerprints/CanScrollVerticallyFingerprint.kt
@@ -8,6 +8,8 @@ object CanScrollVerticallyFingerprint : MethodFingerprint(
     "Z",
     parameters = emptyList(),
     opcodes = listOf(
+        Opcode.MOVE_RESULT,
+        Opcode.RETURN,
         Opcode.INVOKE_VIRTUAL,
         Opcode.MOVE_RESULT,
     ),


### PR DESCRIPTION
The current fingerprint of ```swipe to reload``` fix patch is too short, and reach the wrong class method (the right one is ```n()```).

Patching output with the current fingerprint:

<img width="883" alt="Immagine 2022-12-31 032738" src="https://user-images.githubusercontent.com/120989892/210122436-9b5f55c3-59d0-413b-bc22-a337bc2d7960.png">

With this PR:

<img width="883" alt="Immagine 2022-12-31 032852" src="https://user-images.githubusercontent.com/120989892/210122492-a6d9b8b7-ba33-4c57-8cf9-657cac80b094.png">
