### PR TITLE
fix(youtube/settings-patch): Make back button working

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/resource/patch/ReturnYouTubeDislikeResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/resource/patch/ReturnYouTubeDislikeResourcePatch.kt
@@ -29,7 +29,7 @@ class ReturnYouTubeDislikeResourcePatch : ResourcePatch {
                 Preference.Intent(
                     youtubePackage,
                     "ryd_settings",
-                    "com.google.android.libraries.social.licenses.LicenseActivity"
+                    "com.google.android.apps.youtube.app.settings.videoquality.VideoQualitySettingsActivity"
                 ),
                 StringResource("revanced_ryd_settings_summary", "Settings for Return YouTube Dislike"),
             )

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/resource/patch/SponsorBlockResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/resource/patch/SponsorBlockResourcePatch.kt
@@ -35,7 +35,7 @@ class SponsorBlockResourcePatch : ResourcePatch {
                 Preference.Intent(
                     youtubePackage,
                     "sponsorblock_settings",
-                    "com.google.android.libraries.social.licenses.LicenseActivity"
+                    "com.google.android.apps.youtube.app.settings.videoquality.VideoQualitySettingsActivity"
                 ),
                 StringResource("revanced_sponsorblock_settings_summary", "SponsorBlock related settings"),
             )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/settings/bytecode/fingerprints/LicenseActivityFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/settings/bytecode/fingerprints/LicenseActivityFingerprint.kt
@@ -1,9 +1,0 @@
-package app.revanced.patches.youtube.misc.settings.bytecode.fingerprints
-
-import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
-
-object LicenseActivityFingerprint : MethodFingerprint(
-    customFingerprint = { methodDef ->
-        methodDef.definingClass.endsWith("LicenseActivity;") && methodDef.name == "onCreate"
-    }
-)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/settings/bytecode/patch/SettingsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/settings/bytecode/patch/SettingsPatch.kt
@@ -17,7 +17,6 @@ import app.revanced.patches.shared.settings.preference.impl.Preference
 import app.revanced.patches.shared.settings.util.AbstractPreferenceScreen
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.settings.annotations.SettingsCompatibility
-import app.revanced.patches.youtube.misc.settings.bytecode.fingerprints.LicenseActivityFingerprint
 import app.revanced.patches.youtube.misc.settings.bytecode.fingerprints.ThemeConstructorFingerprint
 import app.revanced.patches.youtube.misc.settings.bytecode.fingerprints.ThemeSetterAppFingerprint
 import app.revanced.patches.youtube.misc.settings.bytecode.fingerprints.ThemeSetterSystemFingerprint
@@ -36,7 +35,7 @@ import org.jf.dexlib2.util.MethodUtil
 @SettingsCompatibility
 @Version("0.0.1")
 class SettingsPatch : BytecodePatch(
-    listOf(LicenseActivityFingerprint, ThemeSetterSystemFingerprint, ThemeConstructorFingerprint)
+    listOf(ThemeSetterSystemFingerprint, ThemeConstructorFingerprint)
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
         fun buildInvokeInstructionsString(
@@ -90,43 +89,11 @@ class SettingsPatch : BytecodePatch(
 
         }
 
-        // set the theme based on the preference of the device
-        with(LicenseActivityFingerprint.result!!) licenseActivity@{
-            with(mutableMethod) {
-                fun buildSettingsActivityInvokeString(
-                    registers: String = "p0",
-                    classDescriptor: String = SETTINGS_ACTIVITY_DESCRIPTOR,
-                    methodName: String = "initializeSettings",
-                    parameters: String = this@licenseActivity.mutableClass.type
-                ) = buildInvokeInstructionsString(registers, classDescriptor, methodName, parameters)
-
-                // initialize the settings
-                addInstructions(
-                    1, """
-                        ${buildSettingsActivityInvokeString()}
-                        return-void
-                    """
-                )
-
-                // set the current theme
-                addInstruction(0, buildSettingsActivityInvokeString(methodName = "setTheme"))
-            }
-
-            // remove method overrides
-            with(mutableClass) {
-                methods.removeIf { it.name != "onCreate" && !MethodUtil.isConstructor(it) }
-            }
-        }
-
         return PatchResultSuccess()
     }
 
     internal companion object {
-        private const val INTEGRATIONS_PACKAGE = "app/revanced/integrations"
-
-        private const val SETTINGS_ACTIVITY_DESCRIPTOR = "L$INTEGRATIONS_PACKAGE/settingsmenu/ReVancedSettingActivity;"
-
-        private const val THEME_HELPER_DESCRIPTOR = "L$INTEGRATIONS_PACKAGE/utils/ThemeHelper;"
+        private const val THEME_HELPER_DESCRIPTOR = "Lapp/revanced/integrations/utils/ThemeHelper;"
         private const val SET_THEME_METHOD_NAME = "setTheme"
 
         fun addString(identifier: String, value: String, formatted: Boolean = true) =

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/settings/resource/patch/SettingsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/settings/resource/patch/SettingsResourcePatch.kt
@@ -73,7 +73,7 @@ class SettingsResourcePatch : AbstractSettingsResourcePatch(
             Preference(
                 StringResource("revanced_settings", "ReVanced"),
                 Preference.Intent(
-                    youtubePackage, "revanced_settings", "com.google.android.libraries.social.licenses.LicenseActivity"
+                    youtubePackage, "revanced_settings", "com.google.android.apps.youtube.app.settings.videoquality.VideoQualitySettingsActivity"
                 ),
                 StringResource("revanced_settings_summary", "ReVanced specific settings"),
             )


### PR DESCRIPTION
RE: https://github.com/revanced/revanced-integrations/pull/267

Closes https://github.com/revanced/revanced-patches/issues/1384.

**Unfortunately I don't have a personal explanation regarding this PR, so I will attach the one provided by inotia00 (the creator of the fix):**

Q. Why did you use ```VideoSettingsActivity``` instead of ```ReVancedSettingsActivity```?
A. To use the back button toolbar, we must define a completely new activity.

And to use a new activity, ```activity``` must be declared in ```AndroidManifest.xml```.

However, adding a new activity to ```AndroidManifest.xml``` is not valid in the ROOT version, so in the past TeamVanced adopted a method of overriding ```LicenseActivity``` with another method.
(They renamed ```XSettingActivity``` to ```LicenseActivity```, then override it)
https://discord.com/channels/952946952348270622/953965039105232906/990620263215411250

However, since there is no way to override the existing smali file on the current method, the method used by TeamVanced could not be adopted as it is.
(If ```LicenseActivity.smali``` already exists in ```YouTube``` and also exists in ```integrations```, it will not be merged)

In the end, the workaround currently used by the ReVanced Team was adopted.

The workaround I've found is:
- Activity is declared in ```AndroidManifest.xml```, but does not exist on smali.
(```LicenseActivity``` also has an activity declared in AndroidManifest.xml, but it already exists on smali.)

The activity that satisfies this is ```VideoQualitySettingsActivity```.
![VideoQualitySettingsActivity](https://user-images.githubusercontent.com/113124331/210177490-b539b371-cf2e-42c8-9ed2-cc1d2c6f5fa2.png)
(`VideoQualitySettingsActivity` is declared in `AndroidManifest.xml` but `VideoQualitySettingsActivity.smali` does not exist on smali)

Therefore, I renamed ```ReVancedSettingsActivity``` to ```VideoQualitySettingsActivity```.
