### PR TITLE
feat(YouTube-Music/compatibility): update to 5.38.53

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/fingerprints/CodecsLockFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/fingerprints/CodecsLockFingerprint.kt
@@ -7,7 +7,7 @@ import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.Opcode
 
 
-@FuzzyPatternScanMethod(2) // FIXME: Test this threshold and find the best value.
+@FuzzyPatternScanMethod(3) // FIXME: Test this threshold and find the best value.
 object CodecsLockFingerprint : MethodFingerprint(
     "L", AccessFlags.PUBLIC or AccessFlags.STATIC, opcodes = listOf(
         Opcode.INVOKE_DIRECT,

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/fingerprints/CodecsLockFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/fingerprints/CodecsLockFingerprint.kt
@@ -7,7 +7,7 @@ import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.Opcode
 
 
-@FuzzyPatternScanMethod(3) // FIXME: Test this threshold and find the best value.
+@FuzzyPatternScanMethod(2) // FIXME: Test this threshold and find the best value.
 object CodecsLockFingerprint : MethodFingerprint(
     "L", AccessFlags.PUBLIC or AccessFlags.STATIC, opcodes = listOf(
         Opcode.INVOKE_DIRECT,
@@ -22,7 +22,7 @@ object CodecsLockFingerprint : MethodFingerprint(
         Opcode.INVOKE_STATIC,
         Opcode.MOVE_RESULT_OBJECT,
         Opcode.INVOKE_INTERFACE,
-        Opcode.INVOKE_DIRECT,
+        Opcode.INVOKE_VIRTUAL,
         Opcode.RETURN_OBJECT
     ),
     strings = listOf("eac3_supported")

--- a/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
@@ -23,7 +23,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.29.52",
             "5.31.50",
             "5.34.51",
-            "5.36.51"
+            "5.36.51",
+            "5.38.53"
         )
     )]
 )


### PR DESCRIPTION
Updates the compatibility of the YouTube Music patches to support `5.28.53`. All patches still work.

The `CodecsLockFingerprint` failed, so I changed `@FuzzyPatternScanMethod(2)` to `@FuzzyPatternScanMethod(3)`, which fixed it.