### PR TITLE
feat(YouTube): ReturnYouTubeDislike compact like button layout

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
@@ -59,7 +59,9 @@ class ReturnYouTubeDislikePatch : BytecodePatch(
 
             val conversionContextParam = 5
             val textRefParam = createComponentMethod.parameters.size - 2
-            val insertIndex = scanResult.stringsScanResult!!.matches.first().index - 2
+            // insert index must be 0, otherwise UI does not updated correctly in some situations
+            // such as switching from full screen or when using previous/next overlay buttons.
+            val insertIndex = 0
 
             createComponentMethod.addInstructions(
                 insertIndex,

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes minimally styled</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes fully styled</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes styled minimally</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled fully</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -18,7 +18,7 @@
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
     <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes styled minimally</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled fully</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled symmetrically</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Like and Dislike displayed together</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Like and Dislike displayed separately</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes displayed together</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes displayed separately</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes displayed together</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes displayed separately</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes minimally styled</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes fully styled</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -16,9 +16,9 @@
     <string name="revanced_ryd_dislike_percentage_summary_on">Dislikes shown as percentage</string>
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
-    <string name="revanced_ryd_compact_layout_title">Compact like button layout</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Showing narrow like button</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Showing normal like button</string>
+    <string name="revanced_ryd_compact_layout_title">Compact like button</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Like and Dislike displayed together</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Like and Dislike displayed separately</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -3,7 +3,6 @@
 
     <string name="revanced_ryd_failure_connection_timeout">Dislikes temporarily not available (API timed out)</string>
     <string name="revanced_ryd_failure_client_rate_limit_requested">Dislikes not available (client API limit reached)</string>
-
     <string name="revanced_ryd_failure_register_user">ReturnYouTubeDislike failed to register as new user</string>
     <string name="revanced_ryd_failure_confirm_user">ReturnYouTubeDislike failed to confirm new user</string>
     <string name="revanced_ryd_failure_send_vote_failed">ReturnYouTubeDislike failed to send vote</string>
@@ -16,6 +15,10 @@
     <string name="revanced_ryd_dislike_percentage_title">Dislikes as percentage</string>
     <string name="revanced_ryd_dislike_percentage_summary_on">Dislikes shown as percentage</string>
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
+
+    <string name="revanced_ryd_compact_layout_title">Compact like button layout</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Showing narrow like button</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Showing normal like button</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes styled minimally</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled symmetrically</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes styled for minimum width</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled for best appearance</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="revanced_ryd_dislike_percentage_summary_off">Dislikes shown as number</string>
 
     <string name="revanced_ryd_compact_layout_title">Compact like button</string>
-    <string name="revanced_ryd_compact_layout_summary_on">Likes and Dislikes styled for minimum width</string>
-    <string name="revanced_ryd_compact_layout_summary_off">Likes and Dislikes styled for best appearance</string>
+    <string name="revanced_ryd_compact_layout_summary_on">Like button styled for minimum width</string>
+    <string name="revanced_ryd_compact_layout_summary_off">Like button styled for best appearance</string>
 
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
     <string name="revanced_ryd_attribution_summary">Dislike data is provided by the Return YouTube Dislike API.  Tap here to learn more.</string>


### PR DESCRIPTION
RE: https://github.com/revanced/revanced-integrations/pull/284

Added an option for a slightly more narrow like button layout, that removes the left separator and tightens the space between the like/dislike by a few more pixels.

Mostly intended for users of devices with strange system fonts (such as [Xiaomi](https://github.com/revanced/revanced-integrations/issues/276)), or any other device where the left separator does not style well.

![compact layout](https://user-images.githubusercontent.com/118716522/211216367-e8e60b29-a5a6-4d5d-8dc6-1619b5cb7ff0.png)

![full size](https://user-images.githubusercontent.com/118716522/211216372-9e0801b1-0af4-4c03-b2f5-5eeedec3828f.png)
