### PR TITLE
fix(Reddit): remove ads patch - specify last version that works correctly

### DIFF
--- a/src/main/kotlin/app/revanced/patches/reddit/ad/general/annotations/GeneralAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/ad/general/annotations/GeneralAdsCompatibility.kt
@@ -3,7 +3,11 @@ package app.revanced.patches.reddit.ad.general.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("com.reddit.frontpage")])
+@Compatibility(
+    [Package(
+        "com.reddit.frontpage", arrayOf("2022.43.0")
+    )]
+)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 internal annotation class GeneralAdsCompatibility


### PR DESCRIPTION
The remove ads patch no longer fully works with the latest versions of Reddit.

Changed the patch so it requires the last version of Reddit that works correctly.