### PR TITLE
feat(finanzonline): Add root and bootloader detection removal patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/fingerprints/BootStateFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/fingerprints/BootStateFingerprint.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.finanzonline.detection.bootloader.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+
+object BootStateFingerprint : MethodFingerprint(
+    "Z",
+    access = AccessFlags.PUBLIC.value,
+    strings = listOf("Boot state of device: %s"),
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("/AttestationHelper;")
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/fingerprints/BootloaderDetectionFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/fingerprints/BootloaderDetectionFingerprint.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.finanzonline.detection.bootloader.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+
+object BootloaderDetectionFingerprint : MethodFingerprint(
+    "Z",
+    access = AccessFlags.PUBLIC.value,
+    strings = listOf("Creation of attestation key succeeded", "Creation of attestation key failed"),
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("/AttestationHelper;")
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/patch/BootloaderDetectionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/patch/BootloaderDetectionPatch.kt
@@ -30,7 +30,7 @@ class BootloaderDetectionPatch : BytecodePatch(
                 """
                         const/4 v0, 0x1
                         return v0
-                      """
+                """
             ) ?: return fingerprint.toErrorResult()
         }
         return PatchResultSuccess()

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/patch/BootloaderDetectionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/bootloader/patch/BootloaderDetectionPatch.kt
@@ -1,0 +1,38 @@
+package app.revanced.patches.finanzonline.detection.bootloader.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.finanzonline.detection.bootloader.fingerprints.BootStateFingerprint
+import app.revanced.patches.finanzonline.detection.bootloader.fingerprints.BootloaderDetectionFingerprint
+import app.revanced.patches.finanzonline.detection.shared.annotations.DetectionCompatibility
+
+
+@Patch
+@Name("remove-bootloader-detection")
+@Description("Removes the check for an unlocked bootloader.")
+@DetectionCompatibility
+@Version("0.0.1")
+class BootloaderDetectionPatch : BytecodePatch(
+    listOf(BootloaderDetectionFingerprint, BootStateFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        arrayOf(BootloaderDetectionFingerprint, BootStateFingerprint).forEach { fingerprint ->
+            fingerprint.result?.mutableMethod?.addInstruction(
+                0,
+                """
+                        const/4 v0, 0x1
+                        return v0
+                      """
+            ) ?: return fingerprint.toErrorResult()
+        }
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/root/fingerprints/RootDetectionFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/root/fingerprints/RootDetectionFingerprint.kt
@@ -1,0 +1,10 @@
+package app.revanced.patches.finanzonline.detection.root.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+
+object RootDetectionFingerprint : MethodFingerprint(
+    "L",
+    customFingerprint = { methodDef ->
+        methodDef.definingClass == "Lat/gv/bmf/bmf2go/tools/utils/z;"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/root/patch/RootDetectionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/root/patch/RootDetectionPatch.kt
@@ -1,0 +1,34 @@
+package app.revanced.patches.finanzonline.detection.root.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.finanzonline.detection.root.fingerprints.RootDetectionFingerprint
+import app.revanced.patches.finanzonline.detection.shared.annotations.DetectionCompatibility
+
+@Patch
+@Name("remove-root-detection")
+@Description("Removes the check for root permissions")
+@DetectionCompatibility
+@Version("0.0.1")
+class RootDetectionPatch : BytecodePatch(
+    listOf(RootDetectionFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        RootDetectionFingerprint.result?.mutableMethod?.addInstructions(
+            0,
+            """
+                sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+                return-object v0
+            """
+        ) ?: return RootDetectionFingerprint.toErrorResult()
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/finanzonline/detection/shared/annotations/DetectionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/finanzonline/detection/shared/annotations/DetectionCompatibility.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.finanzonline.detection.shared.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("at.gv.bmf.bmf2go", arrayOf("2.2.0"))])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class DetectionCompatibility


### PR DESCRIPTION
Removes the root and bootloader check from [FinanzOnline [+]](https://play.google.com/store/apps/details?id=at.gv.bmf.bmf2go)