### PR TITLE
fix(Twitter) specify Twitter version for hide-view-stats

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
@@ -3,7 +3,11 @@ package app.revanced.patches.twitter.layout.hideviews.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("com.twitter.android")])
+@Compatibility(
+    [Package(
+        "com.twitter.android", arrayOf("9.69.1-release.0")
+    )]
+)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 internal annotation class HideViewsCompatibility


### PR DESCRIPTION
hide-view-stats fails to patch with the recent twitter releases.   9.69.1-release.0 is the latest version that patches without errors, and works correctly.