### PR TITLE
fix(YouTube) error when switching on/off interaction setting

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/resource/patch/CopyVideoUrlResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/resource/patch/CopyVideoUrlResourcePatch.kt
@@ -27,18 +27,18 @@ class CopyVideoUrlResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_copy_video_url_settings",
+                "revanced_copy_video_url",
                 StringResource("revanced_copy_video_url_title", "Copy video URL settings"),
                 listOf(
                     SwitchPreference(
-                        "revanced_copy_video_url",
+                        "revanced_copy_video_url_enabled",
                         StringResource("revanced_copy_video_url_enabled_title", "Show copy video URL button"),
                         true,
                         StringResource("revanced_copy_video_url_enabled_summary_on", "Button is shown, click to copy video URL without timestamp"),
                         StringResource("revanced_copy_video_url_enabled_summary_off", "Button is not shown")
                     ),
                     SwitchPreference(
-                        "revanced_copy_video_url_timestamp",
+                        "revanced_copy_video_url_timestamp_enabled",
                         StringResource("revanced_copy_video_url_timestamp_enabled_title", "Show copy timestamp URL button"),
                         true,
                         StringResource("revanced_copy_video_url_timestamp_enabled_summary_on", "Button is shown, click to copy video URL with timestamp"),

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/resource/patch/CopyVideoUrlResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/resource/patch/CopyVideoUrlResourcePatch.kt
@@ -27,7 +27,7 @@ class CopyVideoUrlResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_copy_video_url",
+                "revanced_copy_video_url_settings",
                 StringResource("revanced_copy_video_url_title", "Copy video URL settings"),
                 listOf(
                     SwitchPreference(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/DownloadsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/DownloadsResourcePatch.kt
@@ -26,11 +26,11 @@ class DownloadsResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_downloads_settings",
+                "revanced_downloads",
                 StringResource("revanced_downloads_title", "Download settings"),
                 listOf(
                     SwitchPreference(
-                        "revanced_downloads",
+                        "revanced_downloads_enabled",
                         StringResource("revanced_downloads_enabled_title", "Show download button"),
                         true,
                         StringResource("revanced_downloads_enabled_summary_on", "Download button is shown"),

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/DownloadsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/DownloadsResourcePatch.kt
@@ -26,7 +26,7 @@ class DownloadsResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_downloads",
+                "revanced_downloads_settings",
                 StringResource("revanced_downloads_title", "Download settings"),
                 listOf(
                     SwitchPreference(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/patch/resource/SwipeControlsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/patch/resource/SwipeControlsResourcePatch.kt
@@ -25,7 +25,7 @@ class SwipeControlsResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_swipe_controls_settings", StringResource("revanced_swipe_controls_title", "Swipe controls"), listOf(
+                "revanced_swipe_controls", StringResource("revanced_swipe_controls_title", "Swipe controls"), listOf(
                     SwitchPreference(
                         "revanced_enable_swipe_brightness",
                         StringResource("revanced_swipe_brightness_enabled_title", "Enable brightness gesture"),

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/patch/resource/SwipeControlsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/patch/resource/SwipeControlsResourcePatch.kt
@@ -25,7 +25,7 @@ class SwipeControlsResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             PreferenceScreen(
-                "revanced_swipe_controls", StringResource("revanced_swipe_controls_title", "Swipe controls"), listOf(
+                "revanced_swipe_controls_settings", StringResource("revanced_swipe_controls_title", "Swipe controls"), listOf(
                     SwitchPreference(
                         "revanced_enable_swipe_brightness",
                         StringResource("revanced_swipe_brightness_enabled_title", "Enable brightness gesture"),


### PR DESCRIPTION
fix for error message when switching on/off download video or copy video url.  The error occurred because the preference sub screen used the same key as an existing settings enum.

```
revanced: ReVancedSettingsFragment: Setting COPY_VIDEO_URL_BUTTON_SHOWN was changed. Preference revanced_copy_video_url: Copy video URL settings Settings related to copy URL buttons in video player

revanced: ReVancedSettingsFragment: Setting cannot be handled: class android.preference.PreferenceScreen Copy video URL settings Settings related to copy URL buttons in video player
```

the fix is to use a unique key for the setting enum.

integration changes: https://github.com/revanced/revanced-integrations/pull/307