### PR TITLE
feat(netguard): remove-broadcasts-restriction

### DIFF
--- a/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/annotations/RemoveBroadcastsRestrictionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/annotations/RemoveBroadcastsRestrictionCompatibility.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.netguard.broadcasts.removerestriction.resource.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("eu.faircode.netguard")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RemoveBroadcastsRestrictionCompatibility

--- a/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/patch/RemoveBroadcastsRestrictionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/patch/RemoveBroadcastsRestrictionPatch.kt
@@ -1,0 +1,42 @@
+package app.revanced.patches.netguard.broadcasts.removerestriction.resource.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.ResourcePatch
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.netguard.broadcasts.removerestriction.resource.annotations.RemoveBroadcastsRestrictionCompatibility
+import org.w3c.dom.Element
+
+@Patch(false)
+@Name("remove-broadcasts-restriction")
+@Description("Enables starting/stopping NetGuard via broadcasts.")
+@RemoveBroadcastsRestrictionCompatibility
+@Version("0.0.1")
+class RemoveBroadcastsRestrictionPatch : ResourcePatch {
+    override fun execute(context: ResourceContext): PatchResult {
+        // create an xml editor instance
+        context.xmlEditor["AndroidManifest.xml"].use { dom ->
+            // get the application node
+            val applicationNode = dom
+                .file
+                .getElementsByTagName("application")
+                .item(0) as Element
+
+            applicationNode.getElementsByTagName("receiver").also {  list ->
+                for (i in 0 until list.length) {
+                    val element = list.item(i) as? Element ?: continue
+                    if (element.getAttribute("android:name") == "eu.faircode.netguard.WidgetAdmin") {
+                        element.removeAttribute("android:permission")
+                        break
+                    }
+                }
+            }
+        }
+
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/patch/RemoveBroadcastsRestrictionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/netguard/broadcasts/removerestriction/resource/patch/RemoveBroadcastsRestrictionPatch.kt
@@ -18,9 +18,7 @@ import org.w3c.dom.Element
 @Version("0.0.1")
 class RemoveBroadcastsRestrictionPatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
-        // create an xml editor instance
         context.xmlEditor["AndroidManifest.xml"].use { dom ->
-            // get the application node
             val applicationNode = dom
                 .file
                 .getElementsByTagName("application")


### PR DESCRIPTION
Makes it possible to start/stop [NetGuard](https://github.com/M66B/NetGuard) via automation apps. Example for ADB to start NetGuard:
```
adb shell am broadcast --user 0 -a eu.faircode.netguard.ON eu.faircode.netguard
```