### PR TITLE
fix(twitter/timeline-ads): specify most recent app version that fully works

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/ad/timeline/annotations/TimelineAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/ad/timeline/annotations/TimelineAdsCompatibility.kt
@@ -3,7 +3,11 @@ package app.revanced.patches.twitter.ad.timeline.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("com.twitter.android")])
+@Compatibility(
+    [Package(
+        "com.twitter.android", arrayOf("9.65.3-release.0")
+    )]
+)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 internal annotation class TimelineAdsCompatibility

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.twitter.android", arrayOf("9.69.1-release.0")
+        "com.twitter.android", arrayOf("9.69.1-release.0", "9.71.0-release.0")
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patches.twitter.layout.hideviews.annotations.HideViewsCompatibility
 import org.w3c.dom.Element
 
-@Patch(false)
+@Patch
 @DependsOn([HideViewsBytecodePatch::class])
 @Name("hide-views-stats")
 @Description("Hides the view stats under tweets.")

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patches.twitter.layout.hideviews.annotations.HideViewsCompatibility
 import org.w3c.dom.Element
 
-@Patch
+@Patch(false)
 @DependsOn([HideViewsBytecodePatch::class])
 @Name("hide-views-stats")
 @Description("Hides the view stats under tweets.")


### PR DESCRIPTION
fixes https://github.com/revanced/revanced-patches/issues/352

changed:
- `timeline-ads` to require Twitter version 9.65.3
- `hide-views-stats` changed from default to optional (and added last version that works, `9.71.0`)