### PR TITLE
fix(instagram/hide-timeline-ads): fix compatibility with newer versions

### DIFF
--- a/src/main/kotlin/app/revanced/patches/instagram/patches/ads/timeline/fingerprints/ShowAdFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/instagram/patches/ads/timeline/fingerprints/ShowAdFingerprint.kt
@@ -21,6 +21,5 @@ object ShowAdFingerprint : MethodFingerprint(
         Opcode.CONST_4,
         Opcode.GOTO,
         Opcode.CONST_4,
-        Opcode.RETURN,
     ),
 )


### PR DESCRIPTION
Tested for version 271.1.0.21.84