### PR TITLE
feat(YouTube/GeneralAds): `hide-music-section` in description

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralAdsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralAdsResourcePatch.kt
@@ -220,6 +220,13 @@ class GeneralAdsResourcePatch : ResourcePatch {
                 StringResource("revanced_hide_channel_bar_summary_on", "Channel bar is hidden"),
                 StringResource("revanced_hide_channel_bar_summary_off", "Channel bar is shown")
             ),
+            SwitchPreference(
+                "revanced_hide_description_music_section",
+                StringResource("revanced_hide_description_music_section_title", "Hide music section in description"),
+                true,
+                StringResource("revanced_hide_description_music_section_summary_on", "Music section is hidden"),
+                StringResource("revanced_hide_description_music_section_summary_off", "Music section is shown")
+            ),
         )
 
         PreferenceScreen.ADS.addPreferences(


### PR DESCRIPTION
depends on:

- https://github.com/revanced/revanced-integrations/pull/327