### PR TITLE
Update Gradle Wrapper to 8.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ gradle-app.setting
 
 # Dependency directories
 node_modules/
+
+# gradle properties, due to Github token
+./gradle.properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper to 8.0.1, and also ignore the gradle.properties file

> **Note**
> Users should execute `git update-index --skip-worktree gradle.properties` in order to skip previously tracked gradle.properties