### PR TITLE
feat(youtube): bump compatibility to `18.05.40`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/annotation/GeneralAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/annotation/GeneralAdsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/video/annotations/VideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/video/annotations/VideoAdsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/annotation/CopyVideoUrlCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/annotation/CopyVideoUrlCompatibility.kt
@@ -4,9 +4,18 @@ import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
 @Compatibility(
-    [
-        Package("com.google.android.youtube", arrayOf("17.49.37", "18.03.36"))
-    ]
+    [Package(
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
+    )]
 )
 @Target(AnnotationTarget.CLASS)
 internal annotation class CopyVideoUrlCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/annotation/DownloadsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/annotation/DownloadsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/annotation/SeekbarTappingCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/annotation/SeekbarTappingCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/annotation/SwipeControlsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/annotation/SwipeControlsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/annotations/AutoCaptionsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/annotations/AutoCaptionsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/annotations/HideButtonsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/annotations/HideButtonsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/annotations/AutoplayButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/annotations/AutoplayButtonCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/annotations/HideCaptionsButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/annotations/HideCaptionsButtonCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/pivotbar/shared/annotations/PivotBarCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/pivotbar/shared/annotations/PivotBarCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/background/annotations/PlayerButtonBackgroundCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/background/annotations/PlayerButtonBackgroundCompatibility.kt
@@ -3,9 +3,18 @@ import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
 @Compatibility(
-    [
-        Package("com.google.android.youtube", arrayOf("17.49.37", "18.03.36"))
-    ]
+    [Package(
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
+    )]
 )
 @Target(AnnotationTarget.CLASS)
 internal annotation class PlayerButtonBackgroundCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/annotations/AlbumCardsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/annotations/AlbumCardsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/artistcards/annotations/HideArtistCardCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/artistcards/annotations/HideArtistCardCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/annotations/BreakingNewsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/annotations/BreakingNewsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/comments/annotations/CommentsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/comments/annotations/CommentsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/annotations/CrowdfundingBoxCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/annotations/CrowdfundingBoxCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/annotations/HideEndScreenCardsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/annotations/HideEndScreenCardsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/annotations/HideInfocardsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/annotations/HideInfocardsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/mixplaylists/annotations/MixPlaylistsPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/mixplaylists/annotations/MixPlaylistsPatchCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/personalinformation/annotations/HideEmailAddressCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/personalinformation/annotations/HideEmailAddressCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/annotations/HideTimeCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/annotations/HideTimeCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/watermark/annotations/HideWaterwarkCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/watermark/annotations/HideWaterwarkCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hidetimeandseekbar/annotations/HideTimeAndSeekbarCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hidetimeandseekbar/annotations/HideTimeAndSeekbarCompatibility.kt
@@ -1,4 +1,4 @@
-package app.revanced.patches.youtube.misc.videobuffer.annotations
+package app.revanced.patches.youtube.layout.hidetimeandseekbar.annotations
 
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
@@ -18,4 +18,5 @@ import app.revanced.patcher.annotation.Package
     )]
 )
 @Target(AnnotationTarget.CLASS)
-internal annotation class CustomVideoBufferCompatibility
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class HideTimeAndSeekbarCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/oldqualitylayout/annotations/OldQualityLayoutCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/oldqualitylayout/annotations/OldQualityLayoutCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/panels/fullscreen/remove/annotations/FullscreenPanelsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/panels/fullscreen/remove/annotations/FullscreenPanelsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/annotations/PlayerPopupPanelsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/annotations/PlayerPopupPanelsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/annotations/ReturnYouTubeDislikeCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/annotations/ReturnYouTubeDislikeCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/annotations/SponsorBlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/annotations/SponsorBlockCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/annotations/SpoofAppVersionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/annotations/SpoofAppVersionCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/annotations/StartupShortsResetCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/annotations/StartupShortsResetCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/annotations/TabletMiniPlayerCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/annotations/TabletMiniPlayerCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/widesearchbar/annotations/WideSearchbarCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/widesearchbar/annotations/WideSearchbarCompatibility.kt
@@ -1,4 +1,4 @@
-package app.revanced.patches.youtube.misc.videobuffer.annotations
+package app.revanced.patches.youtube.layout.widesearchbar.annotations
 
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
@@ -18,4 +18,5 @@ import app.revanced.patcher.annotation.Package
     )]
 )
 @Target(AnnotationTarget.CLASS)
-internal annotation class CustomVideoBufferCompatibility
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class WideSearchbarCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/annotations/AutoRepeatCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/annotations/AutoRepeatCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/backtoexitgesture/annotation/FixBackToExitGestureCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/backtoexitgesture/annotation/FixBackToExitGestureCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/hdrbrightness/annotations/HDRBrightnessCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/hdrbrightness/annotations/HDRBrightnessCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/integrations/annotations/IntegrationsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/integrations/annotations/IntegrationsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/open/annotations/OpenLinksExternallyCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/open/annotations/OpenLinksExternallyCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/litho/filter/annotation/LithoFilterCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/litho/filter/annotation/LithoFilterCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/microg/annotations/MicroGPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/microg/annotations/MicroGPatchCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/openlinksdirectly/annotations/OpenLinksDirectlyCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/openlinksdirectly/annotations/OpenLinksDirectlyCompatibility.kt
@@ -1,4 +1,4 @@
-package app.revanced.patches.youtube.misc.videobuffer.annotations
+package app.revanced.patches.youtube.misc.openlinksdirectly.annotations
 
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
@@ -18,4 +18,5 @@ import app.revanced.patcher.annotation.Package
     )]
 )
 @Target(AnnotationTarget.CLASS)
-internal annotation class CustomVideoBufferCompatibility
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class OpenLinksDirectlyCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/playercontrols/annotation/PlayerControlsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/playercontrols/annotation/PlayerControlsCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/playeroverlay/annotation/PlayerOverlaysHookCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/playeroverlay/annotation/PlayerOverlaysHookCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/playertype/annotation/PlayerTypeHookCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/playertype/annotation/PlayerTypeHookCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/information/annotation/VideoInformationCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/information/annotation/VideoInformationCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/quality/annotations/RememberVideoQualityCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/quality/annotations/RememberVideoQualityCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/custom/annotations/CustomPlaybackSpeedCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/custom/annotations/CustomPlaybackSpeedCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/remember/annotation/RememberPlaybackRateCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/remember/annotation/RememberPlaybackRateCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/videoid/annotation/VideoIdCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/videoid/annotation/VideoIdCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37", 
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
✨ Feature - YouTube Music - Bump compatibility from `18.03.36` to `18.05.40`

## 💻 Testing Environment

| 📃 Platform | 📢 Status | 🗓️ ReVanced CLI | 📜 ReVanced Patches | 📔 ReVanced Integrations | 
| --- | --- | --- | --- | --- |
| Windows 11 25309.1000 | ✅ Compiled through `18.05.40` without errors | 2.20.1-dev.1 | 2.165.0-dev.9 | 0.100.0-dev.7 |

## 📱 Testing Environment

| 📃 Platform | 📢 Status |
| --- | --- |
| Samsung M23 5G (`Rooted`, Android 13) | ✋Not all version were tested, see table |

## Tested versions
These versions have been tested against a real device.

- [x] 18.03.42 - ✋ Skipped - Skipped due to 18.05.32 success
- [x] 18.05.32 - ✅ Working - Recommended settings with MicroG Support
- [x] 18.04.35 - ✋ Skipped  - Skipped due to 18.05.35 success
- [x] 18.04.41 - ✋ Skipped  - Skipped due to 18.05.35 success
- [x] 18.05.35 - ✅ Working - Recommended settings with MicroG Support
- [x] 18.05.40  - ✅ Working - Recommended settings with MicroG Support
- [x] 18.06.X^ - ❎ Failed - app.revanced.patcher.patch.PatchResultError: 'x' depends on 'settings'