### PR TITLE
feat(youtube): bump compatibility to 18.05.40 (additional patches)

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/annotations/HideFloatingMicrophoneButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/annotations/HideFloatingMicrophoneButtonCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37",
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/annotations/HideSeekbarCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/annotations/HideSeekbarCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37",
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/watchinvr/annotations/WatchinVRCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/watchinvr/annotations/WatchinVRCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37",
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/annotations/WideSearchbarCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/annotations/WideSearchbarCompatibility.kt
@@ -5,7 +5,16 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube", arrayOf("17.49.37", "18.03.36")
+        "com.google.android.youtube", arrayOf(
+            "17.49.37",
+            "18.03.36",
+            "18.03.42",
+            "18.04.35",
+            "18.04.41",
+            "18.05.32",
+            "18.05.35",
+            "18.05.40"
+        )
     )]
 )
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
a followup to https://github.com/revanced/revanced-patches/pull/1704

4 patches were left out from the version bump:
`enable-wide-searchbar`, `hide-floating-microphone-button`, `hide-seekbar`, `hide-watch-in-vr`

These patches appear to work correctly with 18.05.40

Although I am unable to verify `hide-floating-microphone-button`, as I don't see any difference when using it on 18.03.36 or with 18.05.40 (I don't see any floating microphones anywhere in the app, regardless if the patch is turned on or off).

The other 3 patches work as expected with 18.05.40
