### PR TITLE
refactor(TickTick): clarify `unlock-themes` description

### DIFF
--- a/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/ticktick/misc/themeunlock/patch/UnlockThemePatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.ticktick.misc.themeunlock.fingerprints.SetThemeFinge
 
 @Patch
 @Name("unlock-themes")
-@Description("Unlocks all themes.")
+@Description("Unlocks all themes that are inaccessible until a certain level is reached.")
 @UnlockThemesCompatibility
 @Version("0.0.1")
 class UnlockProPatch : BytecodePatch(


### PR DESCRIPTION
🔧 Refactor - [TickTick](https://play.google.com/store/apps/details?id=com.ticktick.task) - Clarify `unlock-themes` description

refactor(TickTick): clarify the `unlock-themes` patch's description

```diff
- Unlocks all themes.
+ Unlocks all themes that are inaccessible until a certain level is reached.
```

When applying this patch, all themes that require you to reach specific levels are unlocked, but all themes that require you to have premium are not.