### PR TITLE
feat(id-austria): Add version 2.6.0

### DIFF
--- a/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
@@ -3,6 +3,6 @@ package app.revanced.patches.idaustria.detection.shared.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("at.gv.oe.app", arrayOf("2.5.2"))])
+@Compatibility([Package("at.gv.oe.app", arrayOf("2.5.2", "2.6.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class DetectionCompatibility


### PR DESCRIPTION
I have tested the new ID Austria version (`2.6.0`), and the patch still works, so this PR marks the version as compatible.