### PR TITLE
Add patch to hide inbox ads in Facebook Messenger

### DIFF
--- a/src/main/kotlin/app/revanced/patches/messenger/ads/inbox/fingerprints/LoadInboxAdsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/messenger/ads/inbox/fingerprints/LoadInboxAdsFingerprint.kt
@@ -1,0 +1,18 @@
+package app.revanced.patches.messenger.ads.inbox.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+
+object LoadInboxAdsFingerprint : MethodFingerprint(
+    returnType = "V",
+    strings = listOf(
+        "ads_load_begin",
+        "inbox_ads_fetch_start"
+    ),
+    access = AccessFlags.PUBLIC or AccessFlags.STATIC,
+    customFingerprint = {
+        it.definingClass == "Lcom/facebook/messaging/business/inboxads/plugins/inboxads/itemsupplier/InboxAdsItemSupplierImplementation;"
+    }
+)
+

--- a/src/main/kotlin/app/revanced/patches/messenger/ads/inbox/patch/HideInboxAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/messenger/ads/inbox/patch/HideInboxAdsPatch.kt
@@ -1,0 +1,29 @@
+package app.revanced.patches.messenger.ads.inbox.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.*
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.replaceInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.messenger.ads.inbox.fingerprints.LoadInboxAdsFingerprint
+
+@Patch
+@Name("hide-inbox-ads")
+@Description("Hides ads in inbox.")
+@Compatibility([Package("com.facebook.orca")])
+@Version("0.0.1")
+class HideInboxAdsPatch : BytecodePatch(
+    listOf(LoadInboxAdsFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        LoadInboxAdsFingerprint.result?.mutableMethod?.apply {
+            this.replaceInstruction(0, "return-void")
+        } ?: return LoadInboxAdsFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+}
+


### PR DESCRIPTION
Initial version of the patch, verified to work with version `404.0.0.14.115` (released on 2023/04/13).

If needed, I can invest some time to test older versions as well.