### PR TITLE
feat(id-austria): remove version constraint

### DIFF
--- a/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
@@ -3,6 +3,6 @@ package app.revanced.patches.idaustria.detection.shared.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("at.gv.oe.app", arrayOf("2.5.2", "2.6.0", "2.6.1"))])
+@Compatibility([Package("at.gv.oe.app")])
 @Target(AnnotationTarget.CLASS)
 internal annotation class DetectionCompatibility

--- a/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/idaustria/detection/shared/annotations/DetectionCompatibility.kt
@@ -3,6 +3,6 @@ package app.revanced.patches.idaustria.detection.shared.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("at.gv.oe.app", arrayOf("2.5.2", "2.6.0"))])
+@Compatibility([Package("at.gv.oe.app", arrayOf("2.5.2", "2.6.0", "2.6.1"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class DetectionCompatibility


### PR DESCRIPTION
Just tested the patch for version `2.6.1`, and it still works.