### PR TITLE
fix(twitch): minor spelling mistake in Description

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/patch/EmbeddedAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/patch/EmbeddedAdsPatch.kt
@@ -24,7 +24,7 @@ import app.revanced.patches.twitch.misc.settings.bytecode.patch.SettingsPatch
 @Patch
 @DependsOn([VideoAdsPatch::class, IntegrationsPatch::class, SettingsPatch::class])
 @Name("block-embedded-ads")
-@Description("Blocks embedded steam ads using services like TTV.lol or PurpleAdBlocker.")
+@Description("Blocks embedded stream ads using services like TTV.lol or PurpleAdBlocker.")
 @EmbeddedAdsCompatibility
 @Version("0.0.1")
 class EmbeddedAdsPatch : BytecodePatch(


### PR DESCRIPTION
change `steam` to `stream`