### PR TITLE
fix(change-package-name): make option `packageName` `null` by default

### DIFF
--- a/src/main/kotlin/app/revanced/meta/PatchesFileGenerator.kt
+++ b/src/main/kotlin/app/revanced/meta/PatchesFileGenerator.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.patch.Patch
 import app.revanced.patcher.util.patch.PatchBundle
 import java.io.File
 
-typealias PatchBundlePatches = List<Class<out Patch<Context>>>
+internal typealias PatchBundlePatches = List<Class<out Patch<Context>>>
 
 internal interface PatchesFileGenerator {
     fun generate(bundle: PatchBundlePatches)

--- a/src/main/kotlin/app/revanced/patches/all/misc/packagename/patch/ChangePackageNamePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/misc/packagename/patch/ChangePackageNamePatch.kt
@@ -41,7 +41,7 @@ class ChangePackageNamePatch : ResourcePatch {
         var packageName: String? by option(
             PatchOption.StringOption(
                 key = "packageName",
-                default = "",
+                default = null,
                 title = "Package name",
                 description = "The name of the package to rename of the app.",
             )


### PR DESCRIPTION
## TODO

- [x] ~~Solve the issue of loading options with `null` values in ReVanced patcher.~~ https://github.com/revanced/revanced-cli/pull/221