### PR TITLE
 feat(youtube/android-debugging): exclude by default

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/debugging/patch/DebuggingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/debugging/patch/DebuggingPatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.youtube.misc.debugging.annotations.DebuggingCompatib
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.settings.bytecode.patch.SettingsPatch
 
-@Patch
+@Patch(false)
 @Name("enable-debugging")
 @DependsOn([IntegrationsPatch::class, SettingsPatch::class, EnableAndroidDebuggingPatch::class])
 @Description("Adds debugging options.")


### PR DESCRIPTION
According to @oSumAtrIX, it should be excluded by default, but currently it isn't: https://github.com/revanced/revanced-discussions/discussions/979#discussioncomment-5814187