### PR TITLE
feat(youtube/theme): use default seekbar color when option is empty

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/bytecode/patch/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/bytecode/patch/ThemeBytecodePatch.kt
@@ -34,13 +34,13 @@ class ThemeBytecodePatch : BytecodePatch(
             val putColorValueIndex = it.method.indexOfInstructionWithSeekbarId!! + 3
 
             it.mutableMethod.apply {
-                val overrideRegister = instruction<TwoRegisterInstruction>(putColorValueIndex).registerA
+                val colorRegister = instruction<TwoRegisterInstruction>(putColorValueIndex).registerA
 
                 addInstructions(
                     putColorValueIndex,
                     """
-                        invoke-static { }, $INTEGRATIONS_CLASS_DESCRIPTOR->getSeekbarColorValue()I
-                        move-result v$overrideRegister
+                        invoke-static { v$colorRegister }, $INTEGRATIONS_CLASS_DESCRIPTOR->getSeekbarColorValue(I)I
+                        move-result v$colorRegister
                     """
                 )
             }

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/resource/ThemeResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/resource/ThemeResourcePatch.kt
@@ -28,7 +28,7 @@ class ThemeResourcePatch : ResourcePatch {
                 "#FF0000",
                 StringResource(
                     "revanced_seekbar_color_summary",
-                    "The color of the seekbar for the dark theme."
+                    "The color of the seekbar for the dark theme, leave empty to use default."
                 )
             ),
         )


### PR DESCRIPTION
Currently there's no way to have stock YT seekbar color without excluding `theme` patch. This PR makes the patch use stock YT seekbar color when `Seekbar color` option is empty (`""`).

Depends on https://github.com/revanced/revanced-integrations/pull/397