### PR TITLE
chore: remove scopes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug report
 description: Report a very clearly broken issue.
-title: 'bug: <title>'
+title: 'bug(scope): <title>'
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug report
 description: Report a very clearly broken issue.
-title: 'bug(scope): <title>'
+title: 'bug: '
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/patch-request.yml
+++ b/.github/ISSUE_TEMPLATE/patch-request.yml
@@ -24,7 +24,7 @@ body:
   - type: textarea
     attributes:
       label: Motivation
-      description: Why should your patch request should be considered? What makes it valuable to the community?
+      description: Why should your patch request be considered? What makes it valuable to the community?
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/patch-request.yml
+++ b/.github/ISSUE_TEMPLATE/patch-request.yml
@@ -1,6 +1,6 @@
 name: ⭐ Patch Request
 description: Create a detailed patch request.
-title: 'feat(patch): '
+title: 'feat: '
 labels: [patch-request]
 body:
   - type: textarea


### PR DESCRIPTION
# Added

- Add scope to `title` field. Alternatively, use `(patch)` instead of `(scope)`.

# Fixed

-  Fix typo in description of Patch Request