### PR TITLE
there were typo 280p instead of 240p

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/video/quality/patch/RememberVideoQualityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/quality/patch/RememberVideoQualityPatch.kt
@@ -51,7 +51,7 @@ class RememberVideoQualityPatch : BytecodePatch(
             StringResource("revanced_video_quality_default_entry_5", "720p"),
             StringResource("revanced_video_quality_default_entry_6", "480p"),
             StringResource("revanced_video_quality_default_entry_7", "360p"),
-            StringResource("revanced_video_quality_default_entry_8", "280p"),
+            StringResource("revanced_video_quality_default_entry_8", "240p"),
             StringResource("revanced_video_quality_default_entry_9", "144p"),
         )
         val entryValues = listOf(
@@ -62,7 +62,7 @@ class RememberVideoQualityPatch : BytecodePatch(
             StringResource("revanced_video_quality_default_entry_value_5", "720"),
             StringResource("revanced_video_quality_default_entry_value_6", "480"),
             StringResource("revanced_video_quality_default_entry_value_7", "360"),
-            StringResource("revanced_video_quality_default_entry_value_8", "280"),
+            StringResource("revanced_video_quality_default_entry_value_8", "240"),
             StringResource("revanced_video_quality_default_entry_value_9", "144"),
         )
 


### PR DESCRIPTION
there were typo in the patch named RememberVideoQualityPatch.kt, the typo was 280p instead of 240p, which I have fixed.