### PR TITLE
feat(songpal): Add patches for Sony's SongPal

### DIFF
--- a/src/main/kotlin/app/revanced/patches/songpal/badge/annotations/BadgeCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/songpal/badge/annotations/BadgeCompatibility.kt
@@ -1,0 +1,8 @@
+package app.revanced.patches.songpal.badge.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("com.sony.songpal.mdr")])
+@Target(AnnotationTarget.CLASS)
+internal annotation class BadgeCompatibility

--- a/src/main/kotlin/app/revanced/patches/songpal/badge/fingerprints/CreateTabsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/songpal/badge/fingerprints/CreateTabsFingerprint.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.songpal.badge.fingerprints
+
+import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+// Located @ ub.i0.h#p (9.5.0)
+@FuzzyPatternScanMethod(2)
+object CreateTabsFingerprint : MethodFingerprint(
+    "L",
+    accessFlags = AccessFlags.PRIVATE.value,
+    opcodes = listOf(
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.SGET_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.SGET_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.CHECK_CAST,
+        Opcode.RETURN_OBJECT
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/songpal/badge/fingerprints/ShowNotificationFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/songpal/badge/fingerprints/ShowNotificationFingerprint.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.songpal.badge.fingerprints
+
+import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+// Located @ com.sony.songpal.mdr.vim.activity.MdrRemoteBaseActivity.e#run (9.5.0)
+@FuzzyPatternScanMethod(2)
+object ShowNotificationFingerprint : MethodFingerprint(
+    "V",
+    accessFlags = AccessFlags.PUBLIC.value,
+    opcodes = listOf(
+        Opcode.IGET_OBJECT,
+        Opcode.IGET,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.CONST,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.IGET_BOOLEAN,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.CONST,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.RETURN_VOID
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/songpal/badge/patch/BadgeTabPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/songpal/badge/patch/BadgeTabPatch.kt
@@ -1,0 +1,66 @@
+package app.revanced.patches.songpal.badge.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.songpal.badge.annotations.BadgeCompatibility
+import app.revanced.patches.songpal.badge.fingerprints.CreateTabsFingerprint
+
+@Patch
+@Name("remove-badge-tab")
+@Description("Removes the badge tab from the activity tab.")
+@BadgeCompatibility
+@Version("0.0.1")
+class BadgeTabPatch : BytecodePatch(
+    listOf(CreateTabsFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        CreateTabsFingerprint.result?.mutableMethod?.apply {
+            removeInstructions(0, 2)
+
+            val arrayRegister = 0
+            val indexRegister = 1
+            val arrayItemRegister = 2
+
+            // First insert the array of tabs...
+
+            arrayTabs.withIndex().forEach { (index, tab) ->
+                addInstructions(
+                    0,
+                    """
+                        const/4 v$indexRegister, $index
+                        sget-object v$arrayItemRegister, $ACTIVITY_TAB_DESCRIPTOR->$tab:$ACTIVITY_TAB_DESCRIPTOR
+                        aput-object v$arrayItemRegister, v$arrayRegister, v$indexRegister
+                    """
+                )
+            }
+
+            // Then add the instructions to initialize the array.
+            // This is done so that the order of instructions is correct.
+
+            addInstructions(
+                0,
+                """
+                    const/4 v$arrayRegister, ${arrayTabs.size}
+                    new-array v$arrayRegister, v$arrayRegister, [$ACTIVITY_TAB_DESCRIPTOR
+                 """
+            )
+
+        } ?: return CreateTabsFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+
+    companion object {
+        const val ACTIVITY_TAB_DESCRIPTOR = "Ljp/co/sony/vim/framework/ui/yourheadphones/YhContract\$Tab;"
+        val arrayTabs = listOf("Log", "HealthCare")
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/songpal/badge/patch/RemoveNotificationBadgePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/songpal/badge/patch/RemoveNotificationBadgePatch.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.songpal.badge.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.songpal.badge.annotations.BadgeCompatibility
+import app.revanced.patches.songpal.badge.fingerprints.ShowNotificationFingerprint
+
+@Patch
+@Name("remove-notification-badge")
+@Description("Removes the red notification badge from the activity tab.")
+@BadgeCompatibility
+@Version("0.0.1")
+class RemoveNotificationBadgePatch : BytecodePatch(
+    listOf(ShowNotificationFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        ShowNotificationFingerprint.result?.mutableMethod?.apply {
+            addInstructions(0, "return-void")
+        } ?: return ShowNotificationFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
Adds two patches to remove the "Badge" sub-tab in the "Activity" tab (see attached screenshot) as well as the red badge in the bottom navbar on the "Activity" tab since they may be perceived as annoying.


![screen1](https://github.com/revanced/revanced-patches/assets/58902674/cb0d13bb-e810-49d3-9b1b-4131fd3c4569)
