### PR TITLE
feat: Fallback to local.properties if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,6 @@ gradle-app.setting
 # Dependency directories
 node_modules/
 
-# gradle properties, due to Github token
+# gradle properties and local.properties, due to Github token
 ./gradle.properties
+./local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,21 @@
+import java.util.*
+
 plugins {
     kotlin("jvm") version "1.8.10"
 }
 
 group = "app.revanced"
 
-val githubUsername: String = project.findProperty("gpr.user") as? String ?: System.getenv("GITHUB_ACTOR")
-val githubPassword: String = project.findProperty("gpr.key") as? String ?: System.getenv("GITHUB_TOKEN")
+val localProperties = Properties().apply {
+    File(rootProject.rootDir, "local.properties").inputStream().use { load(it) }
+}
+
+fun gitGithubCredential(property: String, env: String): String {
+    return project.findProperty(property) as? String ?: localProperties.getProperty(property) ?: System.getenv(env)
+}
+
+val githubUsername: String = gitGithubCredential("gpr.user", "GITHUB_ACTOR")
+val githubPassword: String = gitGithubCredential("gpr.key", "GITHUB_TOKEN")
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
While `gradle.properties` is listed in `.gitignore`, it is still checked in to the repository since it contains the project's version. 

This may be problematic since `gradle.properties` can also be used to store the Github token required by ReVanced (one could argue that accidentally committing the Github token can be avoided by carefully choosing the files/lines that should be included in the commit, but mistakes happen and I think it's better to play it safe). Therefore, I have added a fallback that looks for the Github user/token in `local.properties` if it is not found in `gradle.properties`.

In my opinion, support for storing the token in `gradle.properties` should be removed altogether, but that is a decision for the ReVanced team to make. 
