### PR TITLE
feat(syncforreddit): add `change-oauth-client-id` patch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
     // Required for FlexVer-Java
     implementation("com.unascribed:flexver-java:1.0.2")
+
+    // A dependency to the Android library unfortunately fails the build,
+    // which is why this is required for the patch change-oauth-client-id
+    compileOnly(project("dummy"))
 }
 
 kotlin {

--- a/dummy/build.gradle.kts
+++ b/dummy/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("java")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}

--- a/dummy/src/main/java/android/os/Environment.java
+++ b/dummy/src/main/java/android/os/Environment.java
@@ -1,0 +1,7 @@
+package android.os;
+
+public final class Environment {
+    public static String getExternalStorageDirectory() {
+        throw new UnsupportedOperationException("Stub");
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
+include("dummy")
+
 rootProject.name = "revanced-patches"

--- a/src/main/kotlin/app/revanced/patches/syncforreddit/ads/annotations/DisableAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/syncforreddit/ads/annotations/DisableAdsCompatibility.kt
@@ -1,8 +1,0 @@
-package app.revanced.patches.syncforreddit.ads.annotations
-
-import app.revanced.patcher.annotation.Compatibility
-import app.revanced.patcher.annotation.Package
-
-@Compatibility([Package("com.laurencedawson.reddit_sync")])
-@Target(AnnotationTarget.CLASS)
-internal annotation class DisableAdsCompatibility

--- a/src/main/kotlin/app/revanced/patches/syncforreddit/ads/patch/DisableAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/syncforreddit/ads/patch/DisableAdsPatch.kt
@@ -1,9 +1,7 @@
 package app.revanced.patches.syncforreddit.ads.patch
 
 import app.revanced.extensions.toErrorResult
-import app.revanced.patcher.annotation.Description
-import app.revanced.patcher.annotation.Name
-import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.annotation.*
 import app.revanced.patcher.data.BytecodeContext
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.patch.BytecodePatch
@@ -11,7 +9,6 @@ import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.DependsOn
 import app.revanced.patcher.patch.annotations.Patch
-import app.revanced.patches.syncforreddit.ads.annotations.DisableAdsCompatibility
 import app.revanced.patches.syncforreddit.ads.fingerprints.IsAdsEnabledFingerprint
 import app.revanced.patches.syncforreddit.detection.piracy.patch.DisablePiracyDetectionPatch
 
@@ -19,8 +16,8 @@ import app.revanced.patches.syncforreddit.detection.piracy.patch.DisablePiracyDe
 @Name("disable-ads")
 @DependsOn([DisablePiracyDetectionPatch::class])
 @Description("Disables ads.")
+@Compatibility([Package("com.laurencedawson.reddit_sync")])
 @Version("0.0.1")
-@DisableAdsCompatibility
 class DisableAdsPatch : BytecodePatch(listOf(IsAdsEnabledFingerprint)) {
     override fun execute(context: BytecodeContext): PatchResult {
         IsAdsEnabledFingerprint.result?.mutableMethod?.apply {

--- a/src/main/kotlin/app/revanced/patches/syncforreddit/api/fingerprints/GetAuthorizationStringFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/syncforreddit/api/fingerprints/GetAuthorizationStringFingerprint.kt
@@ -1,0 +1,7 @@
+package app.revanced.patches.syncforreddit.api.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+
+object GetAuthorizationStringFingerprint : MethodFingerprint(
+    strings = listOf("authorize.compact?client_id")
+)

--- a/src/main/kotlin/app/revanced/patches/syncforreddit/api/fingerprints/GetBearerTokenFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/syncforreddit/api/fingerprints/GetBearerTokenFingerprint.kt
@@ -1,0 +1,7 @@
+package app.revanced.patches.syncforreddit.api.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+
+object GetBearerTokenFingerprint : MethodFingerprint(
+    strings = listOf("Basic")
+)

--- a/src/main/kotlin/app/revanced/patches/syncforreddit/api/patch/ChangeOAuthClientIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/syncforreddit/api/patch/ChangeOAuthClientIdPatch.kt
@@ -1,0 +1,75 @@
+package app.revanced.patches.syncforreddit.api.patch
+
+import app.revanced.patcher.annotation.*
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint.Companion.resolve
+import app.revanced.patcher.patch.*
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.syncforreddit.api.fingerprints.GetAuthorizationStringFingerprint
+import app.revanced.patches.syncforreddit.api.fingerprints.GetBearerTokenFingerprint
+import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
+import org.jf.dexlib2.iface.instruction.ReferenceInstruction
+import org.jf.dexlib2.iface.reference.StringReference
+import java.util.*
+
+@Patch
+@Name("change-oauth-client-id")
+@Description("Changes the OAuth client ID.")
+@Compatibility([Package("com.laurencedawson.reddit_sync")])
+@Version("0.0.1")
+class ChangeOAuthClientIdPatch : BytecodePatch(
+    listOf(GetAuthorizationStringFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        if (clientId == null) return PatchResultError("No client ID provided.")
+
+        GetAuthorizationStringFingerprint.result?.also {
+            if (!GetBearerTokenFingerprint.resolve(context, it.classDef))
+                return PatchResultError("Could not find required method to patch.")
+
+            GetBearerTokenFingerprint.result!!.mutableMethod.apply {
+                val auth = Base64.getEncoder().encodeToString("$clientId:".toByteArray(Charsets.UTF_8))
+                addInstructions(
+                    0,
+                    """
+                         const-string v0, "Basic $auth"
+                         return-object v0
+                    """
+                )
+            }
+        }?.let {
+            val occurrenceIndex = it.scanResult.stringsScanResult!!.matches.first().index
+
+            it.mutableMethod.apply {
+                val authorizationStringInstruction = getInstruction<ReferenceInstruction>(occurrenceIndex)
+                val targetRegister = (authorizationStringInstruction as OneRegisterInstruction).registerA
+                val reference = authorizationStringInstruction.reference as StringReference
+
+                val newAuthorizationUrl = reference.string.replace(
+                    "client_id=.*?&".toRegex(),
+                    "client_id=${clientId!!}&"
+                )
+
+                replaceInstruction(
+                    occurrenceIndex,
+                    "const-string v$targetRegister, \"$newAuthorizationUrl\""
+                )
+            }
+        } ?: return PatchResultError("Could not find required method to patch.")
+        return PatchResultSuccess()
+    }
+
+    companion object : OptionsContainer() {
+        val clientId by option(
+            PatchOption.StringOption(
+                "client-id",
+                null,
+                "OAuth client ID",
+                "The client ID to use for OAuth."
+            )
+        )
+    }
+}


### PR DESCRIPTION
## About

This PR adds a patch for "Sync for Reddit" to change the client id to circumvent the upcoming restrictions on the API enforced by Reddit.

## TODO

- [x] Grabbing the token from the authorization fails with the toast "Error grabbing token", this should be fixed.