### PR TITLE
feat(ytmusic): shorten the app name more

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.music.misc.microg.shared
 
 object Constants {
-    internal const val REVANCED_MUSIC_APP_NAME = "YT Music ReVanced"
+    internal const val REVANCED_MUSIC_APP_NAME = "YT Music"
     internal const val REVANCED_MUSIC_PACKAGE_NAME = "app.revanced.android.apps.youtube.music"
     internal const val MUSIC_PACKAGE_NAME = "com.google.android.apps.youtube.music"
     internal const val SPOOFED_PACKAGE_NAME = MUSIC_PACKAGE_NAME


### PR DESCRIPTION
Some launchers only show 1 line for app label which cut the app label to 'YT Musi...'