### PR TITLE
fix(relayforreddit/change-oauth-client-id): change client id instead of developer key

### DIFF
--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/AbstractClientIdFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/AbstractClientIdFingerprint.kt
@@ -2,6 +2,6 @@ package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprint
 
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 
-object GetClientIdFingerprint : MethodFingerprint(
-    strings = listOf("AIzaSyCTQfRx9fHnDpfcfiI5pmwyGUBjDVTNvX8")
+abstract class AbstractClientIdFingerprint(string: String) : MethodFingerprint(
+    strings = listOfNotNull("dj-xCIZQYiLbEg", string),
 )

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedInBearerTokenFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedInBearerTokenFingerprint.kt
@@ -1,0 +1,4 @@
+package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints
+
+object GetLoggedInBearerTokenFingerprint :
+    AbstractClientIdFingerprint("authorization_code")

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedInBearerTokenFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedInBearerTokenFingerprint.kt
@@ -1,4 +1,3 @@
 package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints
 
-object GetLoggedInBearerTokenFingerprint :
-    AbstractClientIdFingerprint("authorization_code")
+object GetLoggedInBearerTokenFingerprint : AbstractClientIdFingerprint("authorization_code")

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedOutBearerTokenFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetLoggedOutBearerTokenFingerprint.kt
@@ -1,0 +1,3 @@
+package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints
+
+object GetLoggedOutBearerTokenFingerprint : AbstractClientIdFingerprint("https://oauth.reddit.com/grants/installed_client")

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetRefreshTokenFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/GetRefreshTokenFingerprint.kt
@@ -1,0 +1,3 @@
+package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints
+
+object GetRefreshTokenFingerprint : AbstractClientIdFingerprint("refresh_token")

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/LoginActivityClientIdFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/fingerprints/LoginActivityClientIdFingerprint.kt
@@ -1,0 +1,3 @@
+package app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints
+
+object LoginActivityClientIdFingerprint : AbstractClientIdFingerprint("&duration=permanent")

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/patch/ChangeOAuthClientIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/relayforreddit/api/patch/ChangeOAuthClientIdPatch.kt
@@ -3,21 +3,43 @@ package app.revanced.patches.reddit.customclients.relayforreddit.api.patch
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprintResult
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patches.reddit.customclients.AbstractChangeOAuthClientIdPatch
 import app.revanced.patches.reddit.customclients.ChangeOAuthClientIdPatchAnnotation
-import app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints.GetClientIdFingerprint
+import app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints.GetLoggedInBearerTokenFingerprint
+import app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints.GetLoggedOutBearerTokenFingerprint
+import app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints.LoginActivityClientIdFingerprint
+import app.revanced.patches.reddit.customclients.relayforreddit.api.fingerprints.GetRefreshTokenFingerprint
+import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
 
 @ChangeOAuthClientIdPatchAnnotation
 @Compatibility([Package("free.reddit.news"), Package("reddit.news")])
 class ChangeOAuthClientIdPatch : AbstractChangeOAuthClientIdPatch(
-    "dbrady://relay", Options, listOf(GetClientIdFingerprint)
+    "dbrady://relay",
+    Options,
+    listOf(
+        LoginActivityClientIdFingerprint,
+        GetLoggedInBearerTokenFingerprint,
+        GetLoggedOutBearerTokenFingerprint,
+        GetRefreshTokenFingerprint
+    )
 ) {
     override fun List<MethodFingerprintResult>.patch(context: BytecodeContext): PatchResult {
-        first().mutableMethod.replaceInstruction(0, "const-string v0, \"$clientId\"")
+        forEach {
+            val clientIdIndex = it.scanResult.stringsScanResult!!.matches.first().index
+            it.mutableMethod.apply {
+                val clientIdRegister = getInstruction<OneRegisterInstruction>(clientIdIndex).registerA
+
+                it.mutableMethod.replaceInstruction(
+                    clientIdIndex,
+                    "const-string v$clientIdRegister, \"$clientId\""
+                )
+            }
+        }
 
         return PatchResultSuccess()
     }


### PR DESCRIPTION
Changes the patch to change the correct client id.

I somehow naively thought that `DeveloperKey` was the client id, but that's actually just for YouTube.
I tested the app better now to make sure it was actually using my client id.

Also fixes the patching error on the `@ChangeOAuthClientIdPatchAnnotation` by moving `@Patch` out of it.