### PR TITLE
fix(redditisfun/change-oauth-client-id): Add RIF Golden Platinum

### DIFF
--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/redditisfun/api/patch/ChangeOAuthClientIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/redditisfun/api/patch/ChangeOAuthClientIdPatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.reddit.customclients.redditisfun.api.fingerprints.Bu
 import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
 
 @ChangeOAuthClientIdPatchAnnotation
-@Compatibility([Package("com.andrewshu.android.reddit")])
+@Compatibility([Package("com.andrewshu.android.reddit"), Package("com.andrewshu.android.redditdonation")])
 class ChangeOAuthClientIdPatch : AbstractChangeOAuthClientIdPatch(
     "redditisfun://auth",
     Options,


### PR DESCRIPTION
Adds compatibility for "rif is fun golden platinum", RIF's paid ad-free version