### PR TITLE
fix(youtube/spoof-app-version): Removed comma from the Spoof App Version description

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/bytecode/patch/SpoofAppVersionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/bytecode/patch/SpoofAppVersionPatch.kt
@@ -24,7 +24,7 @@ import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
 @Patch
 @DependsOn([IntegrationsPatch::class, SettingsPatch::class])
 @Name("Spoof app version")
-@Description("Tricks YouTube into thinking, you are running an older version of the app. One of the side effects also includes restoring the old UI.")
+@Description("Tricks YouTube into thinking you are running an older version of the app. One of the side effects also includes restoring the old UI.")
 @SpoofAppVersionCompatibility
 @Version("0.0.1")
 class SpoofAppVersionPatch : BytecodePatch(


### PR DESCRIPTION
The Spoof App Version description had an unnecessary comma. (what a big change...)