### PR TITLE
fix(redditisfun): Change User-Agent to generic Android browser UA

### DIFF
--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/redditisfun/api/patch/SpoofClientPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/redditisfun/api/patch/SpoofClientPatch.kt
@@ -60,7 +60,7 @@ class SpoofClientPatch : AbstractSpoofClientPatch(
     override fun List<MethodFingerprintResult>.patchUserAgent(context: BytecodeContext): PatchResult {
         // Use a random user agent.
         val randomName = (0..100000).random()
-        val userAgent = "android:app.revanced.$randomName:v1.0.0 (by /u/revanced)"
+        val userAgent = "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.$randomName Mobile Safari/537.36"
 
         first().mutableMethod.addInstructions(
             0,


### PR DESCRIPTION
As mentioned in my comment in #2727 ([here](https://github.com/ReVanced/revanced-patches/issues/2727#issuecomment-1664391102)), I believe that changing the user agent to something that clearly identifies the app as being modified by revanced presents a security risk:

1) It risks the user of the app being banned by reddit for ToS violations.

2) It risks revanced getting a cease & desist from reddit. 

3) It makes it super easy for reddit to ban these user agents again in the future.

This is because the new way of generating a "more convincing" UA no longer has any plausible deniability. Before, the random number did not distinctly identify the app as being modded by revanced. Now, it does. Personally, I will not be using the patch as-is, because I do not want my account to be banned.

Clearly reddit is doing some type of "detective work" in order to block apps by their user agents. Therefore, a more thoughtful solution than identifying as "revanced" is needed.

~~The first solution that came to my mind is to use a generic browser user agent together with the random number. This prevents reddit from doing a simple search on all user agents containing the phrase "revanced" and blocking them.~~ edit: spoofing the UA is also a ToS violation, so we definitely need a custom UA here.

Let me know your thoughts on this, and let me know if I'm missing any conventions or PR etiquette for this particular project.