### PR TITLE
Remove PowerTube from download recommended app & add Seal

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/ExternalDownloadsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/resource/patch/ExternalDownloadsResourcePatch.kt
@@ -30,7 +30,7 @@ class ExternalDownloadsResourcePatch : ResourcePatch {
                     TextPreference(
                         "revanced_external_downloader_name",
                         StringResource("revanced_external_downloader_name_title", "Downloader package name"),
-                        StringResource("revanced_external_downloader_name_summary", "Package name of your installed external downloader app, such as NewPipe or PowerTube"),
+                        StringResource("revanced_external_downloader_name_summary", "Package name of your installed external downloader app, such as NewPipe or Seal"),
                         InputType.TEXT
                     )
                 ),


### PR DESCRIPTION
Due to the fact that PowerTube has not been consistently maintained and occasionally experiences difficulties in downloading videos. Refer to:
https://github.com/razar-dev/PowerTube/issues/57
https://github.com/razar-dev/PowerTube/issues/56
https://github.com/razar-dev/PowerTube/issues/54

At present, Seal and YTDLnis utilize YT-dlp, resulting in improved output.