### PR TITLE
build: update Gradle to v8.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### 🚀 Gradle v8.3

- [Gradle Changelog](https://docs.gradle.org/8.3/release-notes.html)

This commit update the distributionUrl (or just basically version) in `gradle-wrapper.properties` to use Gradle 8.3