### PR TITLE
feat(tumblr): Add anti-annoyance patches

### DIFF
--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/notifications/fingerprints/IsBlogNotifyEnabledFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/notifications/fingerprints/IsBlogNotifyEnabledFingerprint.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.tumblr.annoyances.notifications.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+
+// The BlogNotifyCtaDialog asks you if you want to enable notifications for a blog.
+// It shows whenever you visit a certain blog for the second time and disables itself
+// if it was shown a total of 3 times (stored in app storage).
+// This targets the BlogNotifyCtaDialog.isEnabled() method to let it always return false.
+object IsBlogNotifyEnabledFingerprint : MethodFingerprint(strings = listOf("isEnabled --> ", "blog_notify_enabled"))

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/notifications/patch/DisableBlogNotificationReminderPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/notifications/patch/DisableBlogNotificationReminderPatch.kt
@@ -1,0 +1,30 @@
+package app.revanced.patches.tumblr.annoyances.notifications.patch
+
+import app.revanced.extensions.exception
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Package
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.tumblr.annoyances.notifications.fingerprints.IsBlogNotifyEnabledFingerprint
+
+@Patch
+@Name("Disable blog notification reminder")
+@Description("Disables the reminder to enable notifications for blogs you visit.")
+@Compatibility([Package("com.tumblr")])
+class DisableBlogNotificationReminderPatch : BytecodePatch(
+    listOf(IsBlogNotifyEnabledFingerprint)
+) {
+    override fun execute(context: BytecodeContext) =
+        IsBlogNotifyEnabledFingerprint.result?.mutableMethod?.addInstructions(
+            0,
+            """
+                # Return false for BlogNotifyCtaDialog.isEnabled() method.
+                const/4 v0, 0x0
+                return v0
+            """
+        ) ?: throw IsBlogNotifyEnabledFingerprint.exception
+}

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/fingerprints/ShowGiftMessagePopupFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/fingerprints/ShowGiftMessagePopupFingerprint.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.tumblr.annoyances.popups.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+
+// This method is responsible for loading and displaying the visual Layout of the Gift Message Popup.
+object ShowGiftMessagePopupFingerprint : MethodFingerprint(
+    strings = listOf("activity", "anchorView"),
+    customFingerprint = { methodDef, _ -> methodDef.definingClass.endsWith("GiftMessagePopup;") }
+)

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/patch/DisableGiftMessagePopupPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/patch/DisableGiftMessagePopupPatch.kt
@@ -1,0 +1,24 @@
+package app.revanced.patches.tumblr.annoyances.popups.patch
+
+import app.revanced.extensions.exception
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Package
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.tumblr.annoyances.popups.fingerprints.ShowGiftMessagePopupFingerprint
+
+@Patch
+@Name("Disable gift message popup")
+@Description("Disables the popup suggesting to buy TumblrMart items for other people.")
+@Compatibility([Package("com.tumblr")])
+class DisableGiftMessagePopupPatch : BytecodePatch(
+    listOf(ShowGiftMessagePopupFingerprint)
+) {
+    override fun execute(context: BytecodeContext) =
+        ShowGiftMessagePopupFingerprint.result?.mutableMethod?.addInstructions(0, "return-void")
+            ?: throw ShowGiftMessagePopupFingerprint.exception
+}


### PR DESCRIPTION
DisableGiftMessagePopupPatch:
Disables the "You can now give back to the people you love" popup when visiting a blog for the first time.
Adds a `return false` at the start of the `BlogNotifyCtaDialog.isEnabled` method

DisableBlogNotificationReminderPatch:
Disables the "Want to get a notification when this person posts?" popup when visiting a specific blog for the second time
Adds a `return` at the start of the `GiftMessagePopup.(showPopup)` method