### PR TITLE
fix(YouTube - Client spoof): Do not record feed videos to history by default

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 @Patch(
     name = "Client spoof",
     description = "Spoofs the client to allow playback.",
-    dependencies = [SpoofSignatureVerificationPatch::class],
+    dependencies = [SpoofSignaturePatch::class],
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube",

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignaturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignaturePatch.kt
@@ -18,14 +18,14 @@ import app.revanced.patches.youtube.misc.playertype.PlayerTypeHookPatch
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 @Patch(
-    description = "Spoofs the client to prevent playback issues.",
+    description = "Spoofs the signature to prevent playback issues.",
     dependencies = [
-        SpoofSignatureVerificationResourcePatch::class,
+        SpoofSignatureResourcePatch::class,
         IntegrationsPatch::class,
         PlayerTypeHookPatch::class
     ]
 )
-object SpoofSignatureVerificationPatch : BytecodePatch(
+object SpoofSignaturePatch : BytecodePatch(
     setOf(
         ProtobufParameterBuilderFingerprint,
         StoryboardThumbnailParentFingerprint,
@@ -33,10 +33,9 @@ object SpoofSignatureVerificationPatch : BytecodePatch(
     )
 ) {
     private const val INTEGRATIONS_CLASS_DESCRIPTOR =
-        "Lapp/revanced/integrations/patches/SpoofSignatureVerificationPatch;"
+        "Lapp/revanced/integrations/patches/SpoofSignaturePatch;"
 
     override fun execute(context: BytecodeContext) {
-
         // hook parameter
         ProtobufParameterBuilderFingerprint.result?.let {
             val setParamMethod = context

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureResourcePatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patches.shared.settings.preference.impl.SwitchPreference
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(dependencies = [SettingsPatch::class, ResourceMappingPatch::class])
-object SpoofSignatureVerificationResourcePatch : ResourcePatch() {
+object SpoofSignatureResourcePatch : ResourcePatch() {
     internal var scrubbedPreviewThumbnailResourceId: Long = -1
 
     override fun execute(context: ResourceContext) {

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureResourcePatch.kt
@@ -31,7 +31,7 @@ object SpoofSignatureResourcePatch : ResourcePatch() {
                                     + "Side effects include:\\n"
                                     + "• No ambient mode\\n"
                                     + "• Videos can't be downloaded\\n"
-                                    + "• Seekbar thumbnails not showing up"
+                                    + "• Seekbar thumbnails are hidden"
                         ),
                         StringResource(
                             "revanced_spoof_signature_verification_enabled_summary_off",
@@ -48,15 +48,14 @@ object SpoofSignatureResourcePatch : ResourcePatch() {
                         StringResource(
                             "revanced_spoof_signature_in_feed_enabled_summary_on",
                             "App signature spoofed\\n\\n"
-                                    + "Automatically played videos in feed will forcibly be recorded in watch history"
+                                    + "Side effects include:\\n"
+                                    + "• Feed videos are missing subtitles\\n"
+                                    + "• Automatically played feed videos will show up in your watch history"
                         ),
                         StringResource(
                             "revanced_spoof_signature_in_feed_enabled_summary_off",
-                            "App signature not spoofed\\n\\nVideo playback in feed may not work"
-                        ),
-                        StringResource(
-                            "revanced_spoof_signature_in_feed_enabled_user_dialog_message",
-                            "Turning off this setting will cause video playback issues."
+                            "App signature not spoofed for feed videos\n\n"
+                                    + "Feed videos will play for less than 1 minute before encountering playback issues"
                         )
                     )
                 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureVerificationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureVerificationPatch.kt
@@ -49,7 +49,7 @@ object SpoofSignatureVerificationPatch : BytecodePatch(
                 addInstructions(
                     0,
                     """
-                        invoke-static {p$protobufParameterRegister}, $INTEGRATIONS_CLASS_DESCRIPTOR->overrideProtobufParameter(Ljava/lang/String;)Ljava/lang/String;
+                        invoke-static {p$protobufParameterRegister}, $INTEGRATIONS_CLASS_DESCRIPTOR->spoofParameter(Ljava/lang/String;)Ljava/lang/String;
                         move-result-object p$protobufParameterRegister
                     """
                 )
@@ -98,7 +98,7 @@ object SpoofSignatureVerificationPatch : BytecodePatch(
                     """
                         iget-object v0, p0, $imageViewFieldName   # copy imageview field to a register
                         invoke-static {v0}, $INTEGRATIONS_CLASS_DESCRIPTOR->seekbarImageViewCreated(Landroid/widget/ImageView;)V
-                """
+                    """
                 )
             }
         } ?: throw ScrubbedPreviewLayoutFingerprint.exception

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureVerificationResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignatureVerificationResourcePatch.kt
@@ -4,6 +4,7 @@ import app.revanced.patcher.data.ResourceContext
 import app.revanced.patcher.patch.ResourcePatch
 import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.patches.shared.mapping.misc.ResourceMappingPatch
+import app.revanced.patches.shared.settings.preference.impl.PreferenceScreen
 import app.revanced.patches.shared.settings.preference.impl.StringResource
 import app.revanced.patches.shared.settings.preference.impl.SwitchPreference
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
@@ -14,18 +15,51 @@ object SpoofSignatureVerificationResourcePatch : ResourcePatch() {
 
     override fun execute(context: ResourceContext) {
         SettingsPatch.PreferenceScreen.MISC.addPreferences(
-            SwitchPreference(
-                "revanced_spoof_signature_verification",
-                StringResource("revanced_spoof_signature_verification_title", "Spoof app signature"),
-                StringResource("revanced_spoof_signature_verification_summary_on",
-                    "App signature spoofed\\n\\n"
-                        + "Side effects include:\\n"
-                        + "• Ambient mode may not work\\n"
-                        + "• Downloading videos may not work\\n"
-                        + "• Seekbar thumbnails are always hidden"),
-                StringResource("revanced_spoof_signature_verification_summary_off", "App signature not spoofed\\n\\nVideo playback may not work"),
-                StringResource("revanced_spoof_signature_verification_user_dialog_message",
-                    "Turning off this setting will cause video playback issues.")
+            PreferenceScreen(
+                key = "revanced_spoof_signature_verification",
+                title = StringResource(
+                    "revanced_spoof_signature_verification_title",
+                    "Spoof app signature"
+                ),
+                preferences = listOf(
+                    SwitchPreference(
+                        "revanced_spoof_signature_verification_enabled",
+                        StringResource("revanced_spoof_signature_verification_enabled_title", "Spoof app signature"),
+                        StringResource(
+                            "revanced_spoof_signature_verification_enabled_summary_on",
+                            "App signature spoofed\\n\\n"
+                                    + "Side effects include:\\n"
+                                    + "• No ambient mode\\n"
+                                    + "• Videos can't be downloaded\\n"
+                                    + "• Seekbar thumbnails not showing up"
+                        ),
+                        StringResource(
+                            "revanced_spoof_signature_verification_enabled_summary_off",
+                            "App signature not spoofed\\n\\nVideo playback may not work"
+                        ),
+                        StringResource(
+                            "revanced_spoof_signature_verification_enabled_user_dialog_message",
+                            "Turning off this setting will cause video playback issues."
+                        )
+                    ),
+                    SwitchPreference(
+                        "revanced_spoof_signature_in_feed_enabled",
+                        StringResource("revanced_spoof_signature_in_feed_enabled_title", "Spoof app signature in feed"),
+                        StringResource(
+                            "revanced_spoof_signature_in_feed_enabled_summary_on",
+                            "App signature spoofed\\n\\n"
+                                    + "Automatically played videos in feed will forcibly be recorded in watch history"
+                        ),
+                        StringResource(
+                            "revanced_spoof_signature_in_feed_enabled_summary_off",
+                            "App signature not spoofed\\n\\nVideo playback in feed may not work"
+                        ),
+                        StringResource(
+                            "revanced_spoof_signature_in_feed_enabled_user_dialog_message",
+                            "Turning off this setting will cause video playback issues."
+                        )
+                    )
+                )
             )
         )
 

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/ScrubbedPreviewLayoutFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/ScrubbedPreviewLayoutFingerprint.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.youtube.misc.fix.playback.fingerprints
 
 import app.revanced.patcher.extensions.or
-import app.revanced.patches.youtube.misc.fix.playback.SpoofSignatureVerificationResourcePatch
+import app.revanced.patches.youtube.misc.fix.playback.SpoofSignatureResourcePatch
 import app.revanced.util.patch.LiteralValueFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -23,5 +23,5 @@ object ScrubbedPreviewLayoutFingerprint : LiteralValueFingerprint(
         Opcode.IPUT_OBJECT, // preview imageview
     ),
     // This resource is used in ~ 40 different locations, but this method has a distinct list of parameters to match to.
-    literalSupplier = { SpoofSignatureVerificationResourcePatch.scrubbedPreviewThumbnailResourceId }
+    literalSupplier = { SpoofSignatureResourcePatch.scrubbedPreviewThumbnailResourceId }
 )


### PR DESCRIPTION
This PR adds the option to disable or enable spoofing the client when playing videos from feeds. The reason is that playback should work for a decent amount (1 minute) where not spoofing is not too much of an issue compared to the video landing in history.  Those who do not care though and want to watch auto-playing videos over a minute can spoof them.

Depends on https://github.com/ReVanced/revanced-integrations/pull/478