### PR TITLE
fix(YouTube - Premium heading): Correct inverted logic

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/branding/header/PremiumHeadingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/branding/header/PremiumHeadingPatch.kt
@@ -32,9 +32,9 @@ object PremiumHeadingPatch : ResourcePatch() {
         val resDirectory = context["res"]
 
         val (original, replacement) = if (usePremiumHeading!!)
-            DEFAULT_HEADING_RES to PREMIUM_HEADING_RES
-        else
             PREMIUM_HEADING_RES to DEFAULT_HEADING_RES
+        else
+            DEFAULT_HEADING_RES to PREMIUM_HEADING_RES
 
         val variants = arrayOf("light", "dark")
 


### PR DESCRIPTION
Fixes an inverted logic caused by the [last commit](https://github.com/ReVanced/revanced-patches/pull/3029/commits/5f2f9676017f524d8315f095b18f1e74e85603f6) of #3029.