### PR TITLE
feat(SPB Serviceportal Bund): Add `Remove root detection` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/serviceportalbund/detection/root/RootDetectionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/serviceportalbund/detection/root/RootDetectionPatch.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.serviceportalbund.detection.root
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.serviceportalbund.detection.root.fingerprints.RootDetectionFingerprint
+
+@Patch(
+    name = "Remove root detection",
+    description = "Removes the check for root permissions and unlocked bootloader.",
+    compatiblePackages = [CompatiblePackage("at.gv.bka.serviceportal")]
+)
+@Suppress("unused")
+object RootDetectionPatch : BytecodePatch(
+    setOf(RootDetectionFingerprint)
+) {
+    override fun execute(context: BytecodeContext) =
+        RootDetectionFingerprint.result!!.mutableMethod.addInstruction(0, "return-void")
+}

--- a/src/main/kotlin/app/revanced/patches/serviceportalbund/detection/root/fingerprints/RootDetectionFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/serviceportalbund/detection/root/fingerprints/RootDetectionFingerprint.kt
@@ -1,0 +1,12 @@
+package app.revanced.patches.serviceportalbund.detection.root.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+object RootDetectionFingerprint : MethodFingerprint(
+    "V",
+    accessFlags = AccessFlags.PUBLIC.value,
+    customFingerprint = { methodDef, _ ->
+        methodDef.definingClass.endsWith("/DeviceIntegrityCheck;")
+    }
+)


### PR DESCRIPTION
Removes the root and bootloader open check from [SPB Serviceportal Bund](https://play.google.com/store/apps/details?id=at.gv.bka.serviceportal&hl=de_AT&gl=US). Based on patch for ID Austria.