### PR TITLE
feat(Tumblr): Add `Disable in-app update` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.tumblr.annoyances.inappupdate
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
+
+@Patch(
+    name = "Disable in-app update",
+    description = "Disable the in-app update check and update prompt",
+    dependencies = [OverrideFeatureFlagsPatch::class],
+    compatiblePackages = [CompatiblePackage("com.tumblr")]
+)
+@Suppress("unused")
+object DisableInAppUpdatePatch : BytecodePatch() {
+    override fun execute(context: BytecodeContext) {
+        // Before checking for updates using the Google play core AppUpdateManager, the value of this feature flag is checked.
+        // If this flag is false or the last update check was today, no update check is performed.
+        OverrideFeatureFlagsPatch.addOverride("inAppUpdate", "false")
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
@@ -15,8 +15,8 @@ import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
 @Suppress("unused")
 object DisableInAppUpdatePatch : BytecodePatch() {
     override fun execute(context: BytecodeContext) {
-        // Before checking for updates using the Google play core AppUpdateManager, the value of this feature flag is checked.
-        // If this flag is false or the last update check was today, no update check is performed.
+        // Before checking for updates using Google Play core AppUpdateManager, the value of this feature flag is checked.
+        // If this flag is false or the last update check was today and no update check is performed.
         OverrideFeatureFlagsPatch.addOverride("inAppUpdate", "false")
     }
 }

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
@@ -8,7 +8,7 @@ import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
 
 @Patch(
     name = "Disable in-app update",
-    description = "Disable the in-app update check and update prompt.",
+    description = "Disables the in-app update check and update prompt.",
     dependencies = [OverrideFeatureFlagsPatch::class],
     compatiblePackages = [CompatiblePackage("com.tumblr")]
 )

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
@@ -8,7 +8,7 @@ import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
 
 @Patch(
     name = "Disable in-app update",
-    description = "Disable the in-app update check and update prompt",
+    description = "Disable the in-app update check and update prompt.",
     dependencies = [OverrideFeatureFlagsPatch::class],
     compatiblePackages = [CompatiblePackage("com.tumblr")]
 )


### PR DESCRIPTION
Once per day, the Tumblr app checks for available app update using the Google play core AppUpdateManager api.  
If an update is available, a banner is shown above the bottom navbar, nudging the user to update.  
When the "Download" button in the banner is pressed, an in-app self-update is apparently supposed to be performed, but this doesn't actually work on my phone so it just causes the banner to disappear for the current day.  
Since updating revanced-patched apps is a bit of a pain, I am adding a patch to disable in-app updates by simply setting the inAppUpdate feature flag to false.