### PR TITLE
feat(YouTube - Return YouTube Dislike): Support version `18.37.36`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -31,7 +31,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
         PlayerTypeHookPatch::class,
     ],
     compatiblePackages = [
-        CompatiblePackage("com.google.android.youtube", ["18.32.39"])
+        CompatiblePackage("com.google.android.youtube", ["18.37.36"])
     ]
 )
 @Suppress("unused")
@@ -89,49 +89,40 @@ object ReturnYouTubeDislikePatch : BytecodePatch(
                 throw TextComponentAtomicReferenceFingerprint.exception
         }?.let { textComponentContextFingerprintResult ->
             val conversionContextIndex = textComponentContextFingerprintResult
-                .scanResult.patternScanResult!!.startIndex
+                .scanResult.patternScanResult!!.endIndex
             val atomicReferenceStartIndex = TextComponentAtomicReferenceFingerprint.result!!
                 .scanResult.patternScanResult!!.startIndex
 
-            val insertIndex = atomicReferenceStartIndex + 6
+            val insertIndex = atomicReferenceStartIndex + 9
 
             textComponentContextFingerprintResult.mutableMethod.apply {
-                // Get the conversion context obfuscated field name, and the registers for the AtomicReference and CharSequence
+                // Get the conversion context obfuscated field name
                 val conversionContextFieldReference =
                     getInstruction<ReferenceInstruction>(conversionContextIndex).reference
 
-                // Reuse the free register to make room for the atomic reference register.
+                // Free register to hold the conversion context
                 val freeRegister =
                     getInstruction<TwoRegisterInstruction>(atomicReferenceStartIndex).registerB
 
                 val atomicReferenceRegister =
-                    getInstruction<FiveRegisterInstruction>(atomicReferenceStartIndex + 1).registerC
+                    getInstruction<FiveRegisterInstruction>(atomicReferenceStartIndex + 6).registerC
 
-                val moveCharSequenceInstruction = getInstruction<TwoRegisterInstruction>(insertIndex - 1)
+                // Instruction that is replaced, and also has the CharacterSequence register.
+                val moveCharSequenceInstruction = getInstruction<TwoRegisterInstruction>(insertIndex)
                 val charSequenceSourceRegister = moveCharSequenceInstruction.registerB
                 val charSequenceTargetRegister = moveCharSequenceInstruction.registerA
 
-                // In order to preserve the atomic reference register, because it is overwritten,
-                // use another free register to store it.
-                replaceInstruction(
-                    atomicReferenceStartIndex + 2,
-                    "move-result-object v$freeRegister"
-                )
-                replaceInstruction(
-                    atomicReferenceStartIndex + 3,
-                    "move-object v$charSequenceSourceRegister, v$freeRegister"
-                )
-
                 // Move the current instance to the free register, and get the conversion context from it.
-                replaceInstruction(insertIndex - 1, "move-object/from16 v$freeRegister, p0")
+                // Must replace the instruction to preserve the control flow label.
+                replaceInstruction(insertIndex, "move-object/from16 v$freeRegister, p0")
                 addInstructions(
-                    insertIndex,
+                    insertIndex + 1,
                     """
                         # Move context to free register
-                        iget-object v$freeRegister, v$freeRegister, $conversionContextFieldReference 
+                        iget-object v$freeRegister, v$freeRegister, $conversionContextFieldReference
                         invoke-static {v$freeRegister, v$atomicReferenceRegister, v$charSequenceSourceRegister}, $INTEGRATIONS_CLASS_DESCRIPTOR->onLithoTextLoaded(Ljava/lang/Object;Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/CharSequence;)Ljava/lang/CharSequence;
                         move-result-object v$freeRegister
-                        # Replace the original char sequence with the modified one.
+                        # Replace the original instruction
                         move-object v${charSequenceTargetRegister}, v${freeRegister}
                     """
                 )
@@ -150,7 +141,7 @@ object ReturnYouTubeDislikePatch : BytecodePatch(
                 val isDisLikesBooleanReference = getInstruction<ReferenceInstruction>(patternResult.endIndex).reference
 
                 val textViewFieldReference = // Like/Dislike button TextView field
-                    getInstruction<ReferenceInstruction>(patternResult.endIndex - 2).reference
+                    getInstruction<ReferenceInstruction>(patternResult.endIndex - 1).reference
 
                 // Check if the hooked TextView object is that of the dislike button.
                 // If RYD is disabled, or the TextView object is not that of the dislike button, the execution flow is not interrupted.

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -51,7 +51,7 @@ object ReturnYouTubeDislikePatch : BytecodePatch(
     override fun execute(context: BytecodeContext) {
         // region Inject newVideoLoaded event handler to update dislikes when a new video is loaded.
 
-        VideoIdPatch.hookVideoId("$INTEGRATIONS_CLASS_DESCRIPTOR->newVideoLoaded(Ljava/lang/String;)V")
+        VideoIdPatch.hookPlayerResponseVideoId("$INTEGRATIONS_CLASS_DESCRIPTOR->newVideoLoaded(Ljava/lang/String;)V")
 
         // endregion
 

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/ShortsTextViewFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/ShortsTextViewFingerprint.kt
@@ -27,7 +27,6 @@ object ShortsTextViewFingerprint : MethodFingerprint(
         Opcode.IF_EQ,
         Opcode.RETURN_VOID,
         Opcode.IGET_OBJECT,     // TextView field
-        Opcode.CHECK_CAST,
         Opcode.IGET_BOOLEAN,    // boolean field
     )
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/TextComponentAtomicReferenceFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/TextComponentAtomicReferenceFingerprint.kt
@@ -13,13 +13,17 @@ object TextComponentAtomicReferenceFingerprint : MethodFingerprint(
     accessFlags = AccessFlags.PROTECTED or AccessFlags.FINAL,
     parameters = listOf("L"),
     opcodes = listOf(
-        Opcode.MOVE_OBJECT, // Register A and B is context, use B as context, reuse A as free register
+        Opcode.MOVE_OBJECT, // Register B is free register
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.MOVE_OBJECT_FROM16,
         Opcode.INVOKE_VIRTUAL, // Register C is atomic reference
         Opcode.MOVE_RESULT_OBJECT, // Register A is char sequence
-        Opcode.MOVE_OBJECT,
         Opcode.CHECK_CAST,
-        Opcode.MOVE_OBJECT,
-        Opcode.INVOKE_INTERFACE, // Insert hook here
+        Opcode.MOVE_OBJECT, // Replace this instruction with patch code
+        Opcode.INVOKE_INTERFACE,
         Opcode.MOVE_RESULT,
         Opcode.IF_EQZ,
         Opcode.INVOKE_INTERFACE,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/TextComponentContextFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/fingerprints/TextComponentContextFingerprint.kt
@@ -13,12 +13,14 @@ object TextComponentContextFingerprint : MethodFingerprint(
     accessFlags = AccessFlags.PROTECTED or AccessFlags.FINAL,
     parameters = listOf("L"),
     opcodes = listOf(
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.MOVE_OBJECT_FROM16,
+        Opcode.INVOKE_STATIC_RANGE,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.IGET_OBJECT,
         Opcode.IGET_OBJECT, // conversion context field name
-        Opcode.IGET_OBJECT,
-        Opcode.IGET_OBJECT,
-        Opcode.IGET_BOOLEAN,
-        Opcode.IGET,
-        Opcode.IGET,
-        Opcode.IGET,
     )
 )


### PR DESCRIPTION
# About

This PR brings back support of Return YouTube Dislike for version  18.37.36.
It fixes the issue with the patch showing the wrong dislikes for Shorts by using a different hook: https://github.com/ReVanced/revanced-patches/commit/e5be42bba237ffcde5fc57b04981b715a7a97c6b.

Logs showed, that this hook is being called with a video id, every time a Short's `TextComponent` was hooked.

# Issues that may occur

Because these are two separate hooks, it is unclear, if synchronization issues could occur. It is also unclear how this hook affects the current patch in detail.