### PR TITLE
feat(YouTube - Hide "Get YouTube Premium" advertisements): Name patch correctly

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -42,7 +42,7 @@ object HideGetPremiumPatch : BytecodePatch(setOf(GetPremiumViewFingerprint)) {
                 "revanced_hide_get_premium",
                 StringResource(
                     "revanced_hide_get_premium_title",
-                    "Hide \"YouTube Premium\" advertisements"
+                    "Hide \"Get YouTube Premium\" advertisements"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_on",

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
-    name = "Hide \"Get Premium\"",
+    name = "Hide \"Get Premium\" advertisements",
     description = "Hides YouTube Premium advertisements under video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -15,7 +15,8 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
-    name = "Hide get premium",
+    name = "Hide \"Get Premium\"",
+    description = "Hides YouTube Premium advertisements under video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
-    name = "Hide \"Get Premium\" advertisements",
+    name = "Hide \"Get YouTube Premium\" advertisements",
     description = "Hides YouTube Premium advertisements under video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -42,7 +42,7 @@ object HideGetPremiumPatch : BytecodePatch(setOf(GetPremiumViewFingerprint)) {
                 "revanced_hide_get_premium",
                 StringResource(
                     "revanced_hide_get_premium_title",
-                    "Hide YouTube premium advertisement"
+                    "Hide \"YouTube Premium\" advertisements"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_on",


### PR DESCRIPTION
Closes https://github.com/ReVanced/revanced-patches/issues/3075

I edited the patch name to `Hide "Get Premium"` just like how the [Hide load more button patch was renamed](https://github.com/ReVanced/revanced-patches/commit/569c3cde9875b807c9116322ca324f69b5fa0218)

I tried checking and it didn't seem like I needed to change any integrations after changing the patch name. 