### PR TITLE
fix(YouTube - Hide get YouTube Premium advertisements): move patch to `Hide ads`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
-    description = "Hides YouTube Premium signup promotion under the video player.",
+    description = "Hides YouTube Premium signup promotions under the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(
@@ -41,15 +41,15 @@ object HideGetPremiumPatch : BytecodePatch(setOf(GetPremiumViewFingerprint)) {
                 "revanced_hide_get_premium",
                 StringResource(
                     "revanced_hide_get_premium_title",
-                    "Hide YouTube Premium promotion"
+                    "Hide YouTube Premium promotions"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_on",
-                    "YouTube Premium promotion under video player is hidden"
+                    "YouTube Premium promotions under video player is hidden"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_off",
-                    "YouTube Premium promotion under video player is shown"
+                    "YouTube Premium promotions under video player is shown"
                 )
             )
         )

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/getpremium/HideGetPremiumPatch.kt
@@ -15,8 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
-    name = "Hide \"Get YouTube Premium\" advertisements",
-    description = "Hides YouTube Premium advertisements under video player.",
+    description = "Hides YouTube Premium signup promotion under the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(
@@ -42,15 +41,15 @@ object HideGetPremiumPatch : BytecodePatch(setOf(GetPremiumViewFingerprint)) {
                 "revanced_hide_get_premium",
                 StringResource(
                     "revanced_hide_get_premium_title",
-                    "Hide \"Get YouTube Premium\" advertisements"
+                    "Hide YouTube Premium promotion"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_on",
-                    "YouTube Premium advertisements under video player are hidden"
+                    "YouTube Premium promotion under video player is hidden"
                 ),
                 StringResource(
                     "revanced_hide_get_premium_summary_off",
-                    "YouTube Premium advertisements under video player are shown"
+                    "YouTube Premium promotion under video player is shown"
                 )
             )
         )


### PR DESCRIPTION
Patch is already part of `Hide ads`, but during the recent refactoring it got a name added by mistake.

Changed "advertisement" to promo, to better indicates it's not advertisements Premium users will see, but instead a promotion to signup for YT Premium.