### PR TITLE
chore(id-austria): Set fixed version for ID Austria

### DIFF
--- a/src/main/kotlin/app/revanced/patches/idaustria/detection/root/RootDetectionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/idaustria/detection/root/RootDetectionPatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patches.idaustria.detection.root.fingerprints.RootDetectionF
 @Patch(
     name = "Remove root detection",
     description = "Removes the check for root permissions and unlocked bootloader.",
-    compatiblePackages = [CompatiblePackage("at.gv.oe.app")]
+    compatiblePackages = [CompatiblePackage("at.gv.oe.app", ["2.7.1"])]
 )
 @Suppress("unused")
 object RootDetectionPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/idaustria/detection/signature/SpoofSignaturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/idaustria/detection/signature/SpoofSignaturePatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patches.idaustria.detection.signature.fingerprints.SpoofSign
 @Patch(
     name = "Spoof signature",
     description = "Spoofs the signature of the app.",
-    compatiblePackages = [CompatiblePackage("at.gv.oe.app")]
+    compatiblePackages = [CompatiblePackage("at.gv.oe.app", ["2.7.1"])]
 )
 @Suppress("unused")
 object SpoofSignaturePatch : BytecodePatch(


### PR DESCRIPTION
The new version `3.0.0` is not supported yet. Not sure when I will have time to check it out, therefore I marked only `2.7.1` as compatible.