### PR TITLE
feat(lightroom): Constrain compatibility to last working version

### DIFF
--- a/src/main/kotlin/app/revanced/patches/lightroom/misc/premium/UnlockPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/lightroom/misc/premium/UnlockPremiumPatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patches.lightroom.misc.premium.fingerprints.HasPurchasedFing
 
 @Patch(
     name = "Unlock premium",
-    compatiblePackages = [CompatiblePackage("com.adobe.lrmobile")]
+    compatiblePackages = [CompatiblePackage("com.adobe.lrmobile", ["9.0.0"])]
 )
 @Suppress("unused")
 object UnlockPremiumPatch : BytecodePatch(


### PR DESCRIPTION
Patching older versions of Lightroom than the one I am constraining to, doesn't cause the patch itself to fail, however it does not unlock any of the premium functions, therefore making the patch itself useless. Hence the constraint to `9.0.0`