### PR TITLE
feat(Twitch): Support version `17.0.0`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/AudioAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/AudioAdsPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.twitch.misc.settings.SettingsPatch
     name = "Block audio ads",
     description = "Blocks audio ads in streams and VODs.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
-    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0"])],
+    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "17.0.0"])],
 )
 @Suppress("unused")
 object AudioAdsPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/EmbeddedAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/EmbeddedAdsPatch.kt
@@ -18,7 +18,7 @@ import app.revanced.patches.twitch.misc.settings.SettingsPatch
     name = "Block embedded ads",
     description = "Blocks embedded stream ads using services like Luminous or PurpleAdBlocker.",
     dependencies = [VideoAdsPatch::class, IntegrationsPatch::class, SettingsPatch::class],
-    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0"])]
+    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "17.0.0"])]
 )
 @Suppress("unused")
 object EmbeddedAdsPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt
@@ -21,7 +21,7 @@ import app.revanced.patches.twitch.misc.settings.SettingsPatch
     name = "Block video ads",
     description = "Blocks video ads in streams and VODs.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
-    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0"])]
+    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "17.0.0"])]
 )
 object VideoAdsPatch : AbstractAdPatch(
     "Lapp/revanced/twitch/patches/VideoAdsPatch;->shouldBlockVideoAds()Z",

--- a/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/ShowDeletedMessagesPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/ShowDeletedMessagesPatch.kt
@@ -22,7 +22,7 @@ import app.revanced.patches.twitch.misc.settings.SettingsPatch
     name = "Show deleted messages",
     description = "Shows deleted chat messages behind a clickable spoiler.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
-    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0"])]
+    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "17.0.0"])]
 )
 @Suppress("unused")
 object ShowDeletedMessagesPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/AutoClaimChannelPointsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/AutoClaimChannelPointsPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.twitch.misc.settings.SettingsPatch
     name = "Auto claim channel points",
     description = "Automatically claim Channel Points.",
     dependencies = [SettingsPatch::class],
-    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0"])]
+    compatiblePackages = [CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "17.0.0"])]
 )
 @Suppress("unused")
 object AutoClaimChannelPointPatch : BytecodePatch(


### PR DESCRIPTION
Continued from #3243

Now supports version `17.0.0` of Twitch.

- the ad patches and “Auto Claim Channel Points” work.
- "shop deleted messages" As I said, I can't test it, I tried but I couldn't test it myself. But the patch is included in this pr

I ask that a maintainer counter-test this because I actually have no idea about Java.
It's better if someone counter-tests it so that there aren't any unidentified errors that I couldn't find