### PR TITLE
fix(Twitch - Settings): Support missing version `16.1.0` and `15.4.1`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
@@ -30,7 +30,7 @@ import java.io.Closeable
     description = "Adds settings menu to Twitch.",
     dependencies = [IntegrationsPatch::class, SettingsResourcePatch::class],
     compatiblePackages = [
-        CompatiblePackage("tv.twitch.android.app", ["16.1.0", "16.9.1"])
+        CompatiblePackage("tv.twitch.android.app", ["15.4.1", "16.1.0", "16.9.1"])
     ]
 )
 object SettingsPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
@@ -30,7 +30,7 @@ import java.io.Closeable
     description = "Adds settings menu to Twitch.",
     dependencies = [IntegrationsPatch::class, SettingsResourcePatch::class],
     compatiblePackages = [
-        CompatiblePackage("tv.twitch.android.app", ["16.9.1"])
+        CompatiblePackage("tv.twitch.android.app", ["16.1.0", "16.9.1"])
     ]
 )
 object SettingsPatch : BytecodePatch(


### PR DESCRIPTION
This will add back the missing versions for Twitch Settings Patch.

Tested successfully with the Twitch version `16.1.0` and `15.4.1`