### PR TITLE
docs: Fix broken link to `VideoAdsPatch`

### DIFF
--- a/docs/3_fingerprinting.md
+++ b/docs/3_fingerprinting.md
@@ -257,7 +257,7 @@ The following properties are utilized by bytecode patches:
 
 ### 🧩 Patches
 
-- [`VideoAdsPatch`](/https://github.com/ReVanced/revanced-patches/blob/7c431c867d62f024855bb07f0723dbbf0af034ae/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt)
+- [`VideoAdsPatch`](https://github.com/ReVanced/revanced-patches/blob/7c431c867d62f024855bb07f0723dbbf0af034ae/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt)
 - [`RememberVideoQualityPatch`](https://github.com/ReVanced/revanced-patches/blob/7c431c867d62f024855bb07f0723dbbf0af034ae/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt)
 
 ### 🔍 Fingerprints


### PR DESCRIPTION
Just found this on my light reading.