### PR TITLE
feat(YouTube): Improve patch descriptions

### DIFF
--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/AbstractGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/AbstractGmsCoreSupportPatch.kt
@@ -24,7 +24,7 @@ import com.android.tools.smali.dexlib2.immutable.reference.ImmutableStringRefere
 import com.android.tools.smali.dexlib2.util.MethodUtil
 
 /**
- * A patch that allows Google apps to run without root and under a different package name
+ * A patch that allows patched Google apps to run without root and under a different package name
  * by using GmsCore instead of Google Play Services.
  *
  * @param fromPackageName The package name of the original app.
@@ -47,7 +47,7 @@ abstract class AbstractGmsCoreSupportPatch(
     fingerprints: Set<MethodFingerprint> = emptySet(),
 ) : BytecodePatch(
     name = "GmsCore support",
-    description = "Allows Google apps to run without root and under a different package name " +
+    description = "Allows patched Google apps to run without root and under a different package name " +
             "by using GmsCore instead of Google Play Services.",
     dependencies = setOf(ChangePackageNamePatch::class, abstractGmsCoreSupportResourcePatch::class) + dependencies,
     compatiblePackages = compatiblePackages,

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/HideAdsPatch.kt
@@ -15,7 +15,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35c
 
 @Patch(
     name = "Hide ads",
-    description = "Removes general ads.",
+    description = "Adds options to remove general ads.",
     dependencies = [
         HideGetPremiumPatch::class,
         HideAdsResourcePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/video/VideoAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/video/VideoAdsPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Video ads",
-    description = "Removes ads in the video player.",
+    description = "Adds option to remove ads in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/video/VideoAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/video/VideoAdsPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Video ads",
-    description = "Adds option to remove ads in the video player.",
+    description = "Adds an option to remove ads in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/CopyVideoUrlBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/CopyVideoUrlBytecodePatch.kt
@@ -8,8 +8,8 @@ import app.revanced.patches.youtube.misc.playercontrols.PlayerControlsBytecodePa
 import app.revanced.patches.youtube.video.information.VideoInformationPatch
 
 @Patch(
-    name = "Copy video url",
-    description = "Adds options to add buttons in the video player to copy video links.",
+    name = "Copy video URL",
+    description = "Adds options to display buttons in the video player to copy video URLs.",
     dependencies = [
         CopyVideoUrlResourcePatch::class,
         PlayerControlsBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/CopyVideoUrlBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/copyvideourl/CopyVideoUrlBytecodePatch.kt
@@ -9,7 +9,7 @@ import app.revanced.patches.youtube.video.information.VideoInformationPatch
 
 @Patch(
     name = "Copy video url",
-    description = "Adds buttons in player to copy video links.",
+    description = "Adds options to add buttons in the video player to copy video links.",
     dependencies = [
         CopyVideoUrlResourcePatch::class,
         PlayerControlsBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Remove viewer discretion dialog",
-    description = "Removes the dialog that appears when you try to watch a video that has been age-restricted " +
+    description = "Adds an option to remove the dialog that appears when opening a video that has been age-restricted " +
             "by accepting it automatically. This does not bypass the age restriction.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
@@ -51,7 +51,7 @@ object RemoveViewerDiscretionDialogPatch : BytecodePatch(
                 ),
                 StringResource(
                     "revanced_remove_viewer_discretion_dialog_user_dialog_message",
-                    "This does not bypass the age restriction, it just accepts it automatically."
+                    "This does not bypass the age restriction. It just accepts it automatically."
                 )
             )
         )

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/ExternalDownloadsBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/downloads/ExternalDownloadsBytecodePatch.kt
@@ -9,7 +9,7 @@ import app.revanced.patches.youtube.video.information.VideoInformationPatch
 
 @Patch(
     name = "External downloads",
-    description = "Adds support to download and save YouTube videos using an external app.",
+    description = "Adds support to download and save YouTube videos using an external downloader app.",
     dependencies = [
         ExternalDownloadsResourcePatch::class,
         PlayerControlsBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
@@ -45,9 +45,9 @@ object DisablePreciseSeekingGesturePatch : BytecodePatch(
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             SwitchPreference(
                 "revanced_disable_precise_seeking_gesture",
-                StringResource("revanced_disable_precise_seeking_gesture_title", "Disable precise seeking"),
-                StringResource("revanced_disable_precise_seeking_gesture_summary_on", "Precise seeking is disabled"),
-                StringResource("revanced_disable_precise_seeking_gesture_summary_off", "Precise seeking is enabled"),
+                StringResource("revanced_disable_precise_seeking_gesture_title", "Disable precise seeking gesture"),
+                StringResource("revanced_disable_precise_seeking_gesture_summary_on", "Gesture is disabled"),
+                StringResource("revanced_disable_precise_seeking_gesture_summary_off", "Gesture is enabled"),
             )
         )
 

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Disable precise seeking gesture",
-    description = "Adds option to disable precise seeking when swiping up on the seekbar.",
+    description = "Adds an option to disable precise seeking when swiping up on the seekbar.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Disable precise seeking gesture",
-    description = "Adds option to disable the gesture that is used to seek precisely when swiping up on the seekbar.",
+    description = "Adds option to disable precise seeking when swiping up on the seekbar.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(
@@ -45,9 +45,9 @@ object DisablePreciseSeekingGesturePatch : BytecodePatch(
         SettingsPatch.PreferenceScreen.INTERACTIONS.addPreferences(
             SwitchPreference(
                 "revanced_disable_precise_seeking_gesture",
-                StringResource("revanced_disable_precise_seeking_gesture_title", "Disable precise seeking gesture"),
-                StringResource("revanced_disable_precise_seeking_gesture_summary_on", "Gesture is disabled"),
-                StringResource("revanced_disable_precise_seeking_gesture_summary_off", "Gesture is enabled"),
+                StringResource("revanced_disable_precise_seeking_gesture_title", "Disable precise seeking"),
+                StringResource("revanced_disable_precise_seeking_gesture_summary_on", "Precise seeking is disabled"),
+                StringResource("revanced_disable_precise_seeking_gesture_summary_off", "Precise seeking is enabled"),
             )
         )
 

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/DisablePreciseSeekingGesturePatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Disable precise seeking gesture",
-    description = "Disables the gesture that is used to seek precisely when swiping up on the seekbar.",
+    description = "Adds option to disable the gesture that is used to seek precisely when swiping up on the seekbar.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSeekbarTappingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSeekbarTappingPatch.kt
@@ -20,7 +20,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Seekbar tapping",
-    description = "Enables tap-to-seek on the seekbar of the video player.",
+    description = "Adds option to enable tap-to-seek on the seekbar of the video player.",
     dependencies = [
         IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSeekbarTappingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSeekbarTappingPatch.kt
@@ -20,7 +20,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Seekbar tapping",
-    description = "Adds option to enable tap-to-seek on the seekbar of the video player.",
+    description = "Adds an option to enable tap-to-seek on the seekbar of the video player.",
     dependencies = [
         IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Enable slide to seek",
-    description = "Enable slide to seek instead of playing at 2x speed when pressing and holding in the video player.",
+    description = "Adds option to enable slide to seek instead of playing at 2x speed when pressing and holding in the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Enable slide to seek",
-    description = "Adds option to enable slide to seek instead of playing at 2x speed when pressing and holding in the video player.",
+    description = "Adds an option to enable slide to seek instead of playing at 2x speed when pressing and holding in the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsBytecodePatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 @Patch(
     name = "Swipe controls",
-    description = "Adds options to enable volume and brightness swipe controls.",
+    description = "Adds options to enable and configure volume and brightness swipe controls.",
     dependencies = [
         IntegrationsPatch::class,
         PlayerTypeHookPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsBytecodePatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 @Patch(
     name = "Swipe controls",
-    description = "Adds volume and brightness swipe controls.",
+    description = "Adds options to enable volume and brightness swipe controls.",
     dependencies = [
         IntegrationsPatch::class,
         PlayerTypeHookPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
@@ -18,7 +18,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable auto captions",
-    description = "Disable forced captions from being automatically enabled.",
+    description = "Adds option to disable forced captions from being automatically enabled.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
@@ -18,7 +18,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable auto captions",
-    description = "Adds option to disable captions from being automatically enabled.",
+    description = "Adds an option to disable captions from being automatically enabled.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/autocaptions/AutoCaptionsPatch.kt
@@ -18,7 +18,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable auto captions",
-    description = "Adds option to disable forced captions from being automatically enabled.",
+    description = "Adds option to disable captions from being automatically enabled.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/branding/CustomBrandingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/branding/CustomBrandingPatch.kt
@@ -12,7 +12,7 @@ import java.nio.file.Files
 
 @Patch(
     name = "Custom branding",
-    description = "Changes the app name and icon to your choice (defaults to \"YouTube ReVanced\" and the ReVanced logo).",
+    description = "Applies a custom app name and icon. Defaults to \"YouTube ReVanced\" and the ReVanced logo.",
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube")
     ],

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/branding/header/PremiumHeadingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/branding/header/PremiumHeadingPatch.kt
@@ -10,7 +10,7 @@ import kotlin.io.path.copyTo
 
 @Patch(
     name = "Premium heading",
-    description = "Show or hide the premium heading.",
+    description = "Adds or removes the YouTube Premium logo at the top of feeds.",
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube")
     ]
@@ -24,7 +24,7 @@ object PremiumHeadingPatch : ResourcePatch() {
         key = "usePremiumHeading",
         default = true,
         title = "Use premium heading",
-        description = "Whether to use the premium heading.",
+        description = "Whether to use the YouTube Premium logo.",
         required = true,
     )
 

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/HideButtonsPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide video action buttons",
-    description = "Adds options to hide action buttons under videos.",
+    description = "Adds options to hide action buttons (such as the Download button) under videos.",
     dependencies = [
         ResourceMappingPatch::class,
         LithoFilterPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/HideButtonsPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide video action buttons",
-    description = "Adds options to hide action buttons under a video.",
+    description = "Adds options to hide action buttons under videos.",
     dependencies = [
         ResourceMappingPatch::class,
         LithoFilterPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/HideAutoplayButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/HideAutoplayButtonPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Hide autoplay button",
-    description = "Hides the autoplay button in the video player.",
+    description = "Adds option to hide the autoplay button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/HideAutoplayButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/autoplay/HideAutoplayButtonPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Hide autoplay button",
-    description = "Adds option to hide the autoplay button in the video player.",
+    description = "Adds an option to hide the autoplay button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/HideCaptionsButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/HideCaptionsButtonPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Hide captions button",
-    description = "Hides the captions button in the video player.",
+    description = "Adds option to hide the captions button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/HideCaptionsButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/captions/HideCaptionsButtonPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Hide captions button",
-    description = "Adds option to hide the captions button in the video player.",
+    description = "Adds an option to hide the captions button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/cast/HideCastButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/cast/HideCastButtonPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide cast button",
-    description = "Adds option to hide the cast button in the video player.",
+    description = "Adds an option to hide the cast button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/cast/HideCastButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/cast/HideCastButtonPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide cast button",
-    description = "Hides the cast button in the video player.",
+    description = "Adds option to hide the cast button in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/navigation/NavigationButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/navigation/NavigationButtonsPatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Navigation buttons",
-    description = "Adds options to hide or change navigation buttons.",
+    description = "Adds options to hide and change navigation buttons (such as the Shorts button).",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rc
 
 @Patch(
     name = "Hide player buttons",
-    description = "Adds option to hide the previous and next buttons in the video player.",
+    description = "Adds an option to hide the previous and next buttons in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rc
 
 @Patch(
     name = "Hide player buttons",
-    description = "Hides previous and next buttons in the video player.",
+    description = "Adds option to hide previous and next buttons in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/player/hide/HidePlayerButtonsPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rc
 
 @Patch(
     name = "Hide player buttons",
-    description = "Adds option to hide previous and next buttons in the video player.",
+    description = "Adds option to hide the previous and next buttons in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide album cards",
-    description = "Adds option to hide album cards below the artist description.",
+    description = "Adds option to hide album cards below artist descriptions.",
     dependencies = [
         IntegrationsPatch::class,
         AlbumCardsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide album cards",
-    description = "Adds option to hide album cards below artist descriptions.",
+    description = "Adds an option to hide album cards below artist descriptions.",
     dependencies = [
         IntegrationsPatch::class,
         AlbumCardsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/albumcards/AlbumCardsPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide album cards",
-    description = "Hides the album cards below the artist description.",
+    description = "Adds option to hide album cards below the artist description.",
     dependencies = [
         IntegrationsPatch::class,
         AlbumCardsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/BreakingNewsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/BreakingNewsPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide breaking news shelf",
-    description = "Adds option to hide the breaking news shelf on the homepage tab.",
+    description = "Adds an option to hide the breaking news shelf on the homepage tab.",
     dependencies = [
         IntegrationsPatch::class,
         BreakingNewsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/BreakingNewsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/breakingnews/BreakingNewsPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide breaking news shelf",
-    description = "Hides the breaking news shelf on the homepage tab.",
+    description = "Adds option to hide the breaking news shelf on the homepage tab.",
     dependencies = [
         IntegrationsPatch::class,
         BreakingNewsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/comments/CommentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/comments/CommentsPatch.kt
@@ -12,7 +12,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Comments",
-    description = "Hides components related to comments.",
+    description = "Adds options to hide components related to comments.",
     dependencies = [
         SettingsPatch::class,
         LithoFilterPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/CrowdfundingBoxPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/CrowdfundingBoxPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide crowdfunding box",
-    description = "Adds option to hide the crowdfunding box between the player and video description.",
+    description = "Adds an option to hide the crowdfunding box between the player and video description.",
     dependencies = [
         IntegrationsPatch::class,
         CrowdfundingBoxResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/CrowdfundingBoxPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/crowdfundingbox/CrowdfundingBoxPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide crowdfunding box",
-    description = "Hides the crowdfunding box between the player and video description.",
+    description = "Adds option to hide the crowdfunding box between the player and video description.",
     dependencies = [
         IntegrationsPatch::class,
         CrowdfundingBoxResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/HideEndscreenCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/HideEndscreenCardsPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c
 
 @Patch(
     name = "Hide endscreen cards",
-    description = "Adds option to hide suggested video cards at the end of videos.",
+    description = "Adds an option to hide suggested video cards at the end of videos.",
     dependencies = [
         IntegrationsPatch::class,
         HideEndscreenCardsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/HideEndscreenCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/endscreencards/HideEndscreenCardsPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c
 
 @Patch(
     name = "Hide endscreen cards",
-    description = "Hides the suggested video cards at the end of videos.",
+    description = "Adds option to hide suggested video cards at the end of videos.",
     dependencies = [
         IntegrationsPatch::class,
         HideEndscreenCardsResourcePatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/filterbar/HideFilterBarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/filterbar/HideFilterBarPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide filter bar",
-    description = "Adds options to hide the filter bar in video feeds.",
+    description = "Adds options to hide the category bar at the top of video feeds.",
     dependencies = [HideFilterBarResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/filterbar/HideFilterBarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/filterbar/HideFilterBarPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide filter bar",
-    description = "Hides the filter bar in video feeds.",
+    description = "Adds options to hide the filter bar in video feeds.",
     dependencies = [HideFilterBarResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide floating microphone button",
-    description = "Adds option to hide the floating microphone button when searching.",
+    description = "Adds an option to hide the floating microphone button when searching.",
     dependencies = [HideFloatingMicrophoneButtonResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide floating microphone button",
-    description = "Hides the floating microphone button which appears in search.",
+    description = "Adds option to hide the floating microphone button which appears in search.",
     dependencies = [HideFloatingMicrophoneButtonResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/floatingmicrophone/HideFloatingMicrophoneButtonPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide floating microphone button",
-    description = "Adds option to hide the floating microphone button which appears in search.",
+    description = "Adds option to hide the floating microphone button when searching.",
     dependencies = [HideFloatingMicrophoneButtonResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/fullscreenambientmode/DisableFullscreenAmbientModePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/fullscreenambientmode/DisableFullscreenAmbientModePatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable fullscreen ambient mode",
-    description = "Disables the ambient mode when in fullscreen.",
+    description = "Adds option to disable the ambient mode when in fullscreen.",
     dependencies = [SettingsPatch::class, IntegrationsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/fullscreenambientmode/DisableFullscreenAmbientModePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/fullscreenambientmode/DisableFullscreenAmbientModePatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable fullscreen ambient mode",
-    description = "Adds option to disable the ambient mode when in fullscreen.",
+    description = "Adds an option to disable the ambient mode when in fullscreen.",
     dependencies = [SettingsPatch::class, IntegrationsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -24,7 +24,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide layout components",
-    description = "Hides general layout components.",
+    description = "Adds options to hide general layout components.",
     dependencies = [
         LithoFilterPatch::class,
         SettingsPatch::class

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 @Patch(
     name = "Hide info cards",
-    description = "Adds option to hide info cards that creators add in the video player.",
+    description = "Adds an option to hide info cards that creators add in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 @Patch(
     name = "Hide info cards",
-    description = "Hides info cards in videos.",
+    description = "Adds option to hide info cards in videos.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 @Patch(
     name = "Hide info cards",
-    description = "Adds option to hide info cards in videos.",
+    description = "Adds option to hide info cards that creators add in the video player.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/loadmorebutton/HideLoadMoreButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/loadmorebutton/HideLoadMoreButtonPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide \'Load more\' button",
-    description = "Hides the button under videos that loads similar videos.",
+    description = "Adds option to hide the button under videos that loads similar videos.",
     dependencies = [HideLoadMoreButtonResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/loadmorebutton/HideLoadMoreButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/loadmorebutton/HideLoadMoreButtonPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Hide \'Load more\' button",
-    description = "Adds option to hide the button under videos that loads similar videos.",
+    description = "Adds an option to hide the button under videos that loads similar videos.",
     dependencies = [HideLoadMoreButtonResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/player/flyoutmenupanel/HidePlayerFlyoutMenuPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/player/flyoutmenupanel/HidePlayerFlyoutMenuPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Player flyout menu",
-    description = "Hides player flyout menu items.",
+    description = "Adds options to hide player flyout menu items.",
     dependencies = [
         LithoFilterPatch::class,
         PlayerTypeHookPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/player/flyoutmenupanel/HidePlayerFlyoutMenuPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/player/flyoutmenupanel/HidePlayerFlyoutMenuPatch.kt
@@ -13,7 +13,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Player flyout menu",
-    description = "Adds options to hide player flyout menu items.",
+    description = "Adds options to hide menu items that appear when pressing the gear icon in the video player.",
     dependencies = [
         LithoFilterPatch::class,
         PlayerTypeHookPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Disable rolling number animations",
-    description = "Disables rolling number animations of video view count, user likes, and upload time.",
+    description = "Adds option to disable rolling number animations of video view count, user likes, and upload time.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Disable rolling number animations",
-    description = "Adds option to disable rolling number animations of video view count, user likes, and upload time.",
+    description = "Adds an option to disable rolling number animations of video view count, user likes, and upload time.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/HideSeekbarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/HideSeekbarPatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.youtube.shared.fingerprints.SeekbarOnDrawFingerprint
 
 @Patch(
     name = "Hide seekbar",
-    description = "Adds option to hide the seekbar.",
+    description = "Adds an option to hide the seekbar.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/HideSeekbarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/seekbar/HideSeekbarPatch.kt
@@ -16,7 +16,7 @@ import app.revanced.patches.youtube.shared.fingerprints.SeekbarOnDrawFingerprint
 
 @Patch(
     name = "Hide seekbar",
-    description = "Hides the seekbar.",
+    description = "Adds option to hide the seekbar.",
     dependencies = [
         IntegrationsPatch::class,
         SettingsPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -20,7 +20,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Hide Shorts components",
-    description = "Hides components from YouTube Shorts.",
+    description = "Adds options to hide components related to YouTube Shorts.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/suggestedvideoendscreen/DisableSuggestedVideoEndScreenPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/suggestedvideoendscreen/DisableSuggestedVideoEndScreenPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Disable suggested video end screen",
-    description = "Adds option to disable the suggested video end screen at the end of videos.",
+    description = "Adds an option to disable the suggested video end screen at the end of videos.",
     dependencies = [IntegrationsPatch::class, DisableSuggestedVideoEndScreenResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/suggestedvideoendscreen/DisableSuggestedVideoEndScreenPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/suggestedvideoendscreen/DisableSuggestedVideoEndScreenPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Disable suggested video end screen",
-    description = "Disables the suggested video end screen at the end of a video.",
+    description = "Adds option to disable the suggested video end screen at the end of videos.",
     dependencies = [IntegrationsPatch::class, DisableSuggestedVideoEndScreenResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide timestamp",
-    description = "Adds option to hide the timestamp in the bottom left of the video player.",
+    description = "Adds an option to hide the timestamp in the bottom left of the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide timestamp",
-    description = "Adds option to hide the timestamp in the video player.",
+    description = "Adds option to hide the timestamp in the bottom left of the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/time/HideTimestampPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Hide timestamp",
-    description = "Hides timestamp in video player.",
+    description = "Adds option to hide the timestamp in the video player.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/PlayerPopupPanelsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/PlayerPopupPanelsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable player popup panels",
-    description = "Disables panels (such as live chat) from opening automatically.",
+    description = "Adds option to disable panels (such as live chat) from opening automatically.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/PlayerPopupPanelsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/panels/popup/PlayerPopupPanelsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable player popup panels",
-    description = "Adds option to disable panels (such as live chat) from opening automatically.",
+    description = "Adds an option to disable panels (such as live chat) from opening automatically.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/player/background/PlayerControlsBackgroundPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/player/background/PlayerControlsBackgroundPatch.kt
@@ -9,7 +9,7 @@ import org.w3c.dom.Element
 
 @Patch(
     name = "Remove player controls background",
-    description = "Removes the background from the video player controls.",
+    description = "Removes the dark background surrounding the video player controls.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube", [

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Custom player overlay opacity",
-    description = "Change the opacity of the player background when player controls are visible.",
+    description = "Adds option to change the opacity of the player background when player controls are visible.",
     dependencies = [CustomPlayerOverlayOpacityResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Custom player overlay opacity",
-    description = "Adds option to change the opacity of the player background when player controls are visible.",
+    description = "Adds option to change the opacity of the video player background when player controls are visible.",
     dependencies = [CustomPlayerOverlayOpacityResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Custom player overlay opacity",
-    description = "Adds option to change the opacity of the video player background when player controls are visible.",
+    description = "Adds an option to change the opacity of the video player background when player controls are visible.",
     dependencies = [CustomPlayerOverlayOpacityResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -27,7 +27,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Return YouTube Dislike",
-    description = "Shows the dislike count of videos using the Return YouTube Dislike API.",
+    description = "Adds option to show the dislike count of videos using the Return YouTube Dislike API.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -27,7 +27,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Return YouTube Dislike",
-    description = "Adds option to show the dislike count of videos using the Return YouTube Dislike API.",
+    description = "Adds an option to show the dislike count of videos using the Return YouTube Dislike API.",
     dependencies = [
         IntegrationsPatch::class,
         LithoFilterPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/WideSearchbarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/WideSearchbarPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Wide searchbar",
-    description = "Replaces the search icon with a wide search bar. This will hide the YouTube logo when active.",
+    description = "Adds option to replace the search icon with a wide search bar. This will hide the YouTube logo when active.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/WideSearchbarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/searchbar/WideSearchbarPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Wide searchbar",
-    description = "Adds option to replace the search icon with a wide search bar. This will hide the YouTube logo when active.",
+    description = "Adds an option to replace the search icon with a wide search bar. This will hide the YouTube logo when active.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Restore old seekbar thumbnails",
-    description = "Adds option to restore the old seekbar thumbnails that appear above the seekbar while seeking instead of fullscreen thumbnails.",
+    description = "Adds an option to restore the old seekbar thumbnails that appear above the seekbar while seeking instead of fullscreen thumbnails.",
     dependencies = [IntegrationsPatch::class, SeekbarPreferencesPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Restore old seekbar thumbnails",
-    description = "Restores the old seekbar thumbnails that appear above the seekbar instead of fullscreen thumbnails.",
+    description = "Adds option to restore the old seekbar thumbnails that appear above the seekbar instead of fullscreen thumbnails.",
     dependencies = [IntegrationsPatch::class, SeekbarPreferencesPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/seekbar/RestoreOldSeekbarThumbnailsPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Restore old seekbar thumbnails",
-    description = "Adds option to restore the old seekbar thumbnails that appear above the seekbar instead of fullscreen thumbnails.",
+    description = "Adds option to restore the old seekbar thumbnails that appear above the seekbar while seeking instead of fullscreen thumbnails.",
     dependencies = [IntegrationsPatch::class, SeekbarPreferencesPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/SponsorBlockBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/SponsorBlockBytecodePatch.kt
@@ -34,7 +34,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Patch(
     name = "SponsorBlock",
-    description = "Integrates SponsorBlock, which can skip undesired video segments such as sponsored content.",
+    description = "Adds option to enable SponsorBlock, which can skip undesired video segments such as sponsored content.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube", [

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/SponsorBlockBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/sponsorblock/SponsorBlockBytecodePatch.kt
@@ -34,7 +34,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Patch(
     name = "SponsorBlock",
-    description = "Adds option to enable SponsorBlock, which can skip undesired video segments such as sponsored content.",
+    description = "Adds options to enable and configure SponsorBlock, which can skip undesired video segments such as sponsored content.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube", [

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Spoof app version",
-    description = "Tricks YouTube into thinking you are running an older version of the app. " +
+    description = "Adds option to trick YouTube into thinking you are running an older version of the app. " +
             "This can be used to restore old UI elements and features.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Spoof app version",
-    description = "Adds option to trick YouTube into thinking you are running an older version of the app. " +
+    description = "Adds an option to trick YouTube into thinking you are running an older version of the app. " +
             "This can be used to restore old UI elements and features.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
@@ -16,7 +16,7 @@ import app.revanced.util.exception
 
 @Patch(
     name = "Change start page",
-    description = "Changes the start page of the app.",
+    description = "Adds option to change the start page of the app.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
@@ -16,7 +16,7 @@ import app.revanced.util.exception
 
 @Patch(
     name = "Change start page",
-    description = "Adds option to change the start page of the app.",
+    description = "Adds option to set which page the app opens in instead of the homepage.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
@@ -16,7 +16,7 @@ import app.revanced.util.exception
 
 @Patch(
     name = "Change start page",
-    description = "Adds option to set which page the app opens in instead of the homepage.",
+    description = "Adds an option to set which page the app opens in instead of the homepage.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable resuming Shorts on startup",
-    description = "Adds option to disable the Shorts player from resuming on app startup when Shorts were last being watched.",
+    description = "Adds an option to disable the Shorts player from resuming on app startup when Shorts were last being watched.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable resuming Shorts on startup",
-    description = "Disables resuming the Shorts player on app startup if a Short was last opened.",
+    description = "Adds option to disable the Shorts player from resuming on app startup if a Short was last opened.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Disable resuming Shorts on startup",
-    description = "Adds option to disable the Shorts player from resuming on app startup if a Short was last opened.",
+    description = "Adds option to disable the Shorts player from resuming on app startup when Shorts were last being watched.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/tablet/EnableTabletLayoutPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/tablet/EnableTabletLayoutPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Enable tablet layout",
-    description = "Spoofs the device form factor to a tablet which enables the tablet layout.",
+    description = "Adds option to spoof the device form factor to a tablet which enables the tablet layout.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/tablet/EnableTabletLayoutPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/tablet/EnableTabletLayoutPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Enable tablet layout",
-    description = "Adds option to spoof the device form factor to a tablet which enables the tablet layout.",
+    description = "Adds an option to spoof the device form factor to a tablet which enables the tablet layout.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/TabletMiniPlayerPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/TabletMiniPlayerPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Tablet mini player",
-    description = "Enables the tablet mini player layout.",
+    description = "Adds option to enable the tablet mini player layout.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/TabletMiniPlayerPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/tabletminiplayer/TabletMiniPlayerPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Tablet mini player",
-    description = "Adds option to enable the tablet mini player layout.",
+    description = "Adds an option to enable the tablet mini player layout.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Theme",
-    description = "Adds options for theming and applies a custom background theme (dark background defaults to amoled black).",
+    description = "Adds options for theming and applies a custom background theme (dark background theme defaults to amoled black).",
     dependencies = [
         LithoColorHookPatch::class,
         SeekbarColorBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Theme",
-    description = "Applies a custom theme.",
+    description = "Adds options for theming and applies a custom background theme.",
     dependencies = [
         LithoColorHookPatch::class,
         SeekbarColorBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Theme",
-    description = "Adds options for theming and applies a custom background theme.",
+    description = "Adds options for theming and applies a custom background theme (dark background defaults to amoled black).",
     dependencies = [
         LithoColorHookPatch::class,
         SeekbarColorBytecodePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
@@ -29,7 +29,7 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 @Patch(
     name = "Alternative thumbnails",
-    description = "Adds options to replace video thumbnails with still image captures of the video.",
+    description = "Adds options to replace video thumbnails using the DeArrow API or image captures from the video.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class, AlternativeThumbnailsResourcePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
@@ -150,7 +150,7 @@ object AlternativeThumbnailsPatch : BytecodePatch(
                             "revanced_alt_thumbnail_dearrow_about_summary",
                             "DeArrow provides crowd-sourced thumbnails for YouTube videos. " +
                                     "These thumbnails are often more relevant than those provided by YouTube. " +
-                                    "If enabled, video URLs will be sent to the API server and no other data is sent."
+                                    "If enabled, video URLs will be sent to the API server and no other data is sent"
                                     + "\\n\\nTap here to learn more about DeArrow"
                         ),
                         // Custom about preference with link to the DeArrow website.

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -15,7 +15,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Announcements",
-    description = "Shows ReVanced announcements on startup.",
+    description = "Adds option to show ReVanced announcements on startup.",
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")],
     dependencies = [SettingsPatch::class]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -15,7 +15,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Announcements",
-    description = "Adds option to show ReVanced announcements on startup.",
+    description = "Adds option to show announcements from ReVanced on startup.",
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")],
     dependencies = [SettingsPatch::class]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -15,7 +15,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Announcements",
-    description = "Adds option to show announcements from ReVanced on startup.",
+    description = "Adds option to show announcements from ReVanced on app startup.",
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")],
     dependencies = [SettingsPatch::class]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -15,7 +15,7 @@ import com.android.tools.smali.dexlib2.Opcode
 
 @Patch(
     name = "Announcements",
-    description = "Adds option to show announcements from ReVanced on app startup.",
+    description = "Adds an option to show announcements from ReVanced on app startup.",
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")],
     dependencies = [SettingsPatch::class]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Always autorepeat",
-    description = "Always repeats the playing video again.",
+    description = "Adds option to always repeat the playing video again.",
     dependencies = [IntegrationsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
@@ -16,8 +16,8 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 
 @Patch(
-    name = "Always autorepeat",
-    description = "Adds option to always repeat the playing video again.",
+    name = "Always repeat",
+    description = "Adds option to always repeat videos when they end.",
     dependencies = [IntegrationsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/autorepeat/AutoRepeatPatch.kt
@@ -17,7 +17,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Always repeat",
-    description = "Adds option to always repeat videos when they end.",
+    description = "Adds an option to always repeat videos when they end.",
     dependencies = [IntegrationsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/debugging/DebuggingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/debugging/DebuggingPatch.kt
@@ -11,7 +11,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Enable debugging",
-    description = "Adds debugging options.",
+    description = "Adds options for debugging.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
@@ -44,7 +44,7 @@ object SpoofDeviceDimensionsPatch : BytecodePatch(
                 StringResource(
                     "revanced_spoof_device_dimensions_summary_off",
                     "Device dimensions not spoofed\\n\\n"
-                        + "Spoofing the device dimensions can unlock higher video qualities but unkown side effects may occur"
+                        + "Spoofing the device dimensions can unlock higher video qualities but unknown side effects may occur"
                     ),
             )
         )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Spoof device dimensions",
-    description = "Adds option to spoof the device dimensions which unlocks higher video qualities if they aren't available on the device.",
+    description = "Adds an option to spoof the device dimensions which unlocks higher video qualities if they aren't available on the device.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
@@ -41,7 +41,11 @@ object SpoofDeviceDimensionsPatch : BytecodePatch(
                 "revanced_spoof_device_dimensions",
                 StringResource("revanced_spoof_device_dimensions_title", "Spoof device dimensions"),
                 StringResource("revanced_spoof_device_dimensions_summary_on", "Device dimensions spoofed"),
-                StringResource("revanced_spoof_device_dimensions_summary_off", "Device dimensions not spoofed"),
+                StringResource(
+                    "revanced_spoof_device_dimensions_summary_off",
+                    "Device dimensions not spoofed\\n\\n"
+                        + "Spoofing the device dimensions can unlock higher video qualities but unkown side effects may occur"
+                    ),
             )
         )
 

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
@@ -14,8 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Spoof device dimensions",
-    description = "Spoofs the device dimensions in order to unlock higher video qualities " +
-            "that may not be available on your device.",
+    description = "Adds option to spoof the device dimensions in order to unlock higher video qualities that may not be available on your device.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/dimensions/spoof/SpoofDeviceDimensionsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
 @Patch(
     name = "Spoof device dimensions",
-    description = "Adds option to spoof the device dimensions in order to unlock higher video qualities that may not be available on your device.",
+    description = "Adds option to spoof the device dimensions which unlocks higher video qualities if they aren't available on the device.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Client spoof",
-    description = "Spoofs the client to allow playback.",
+    description = "Adds options to spoof the client to allow video playback.",
     dependencies = [SpoofSignaturePatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/BypassURLRedirectsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/BypassURLRedirectsPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Bypass URL redirects",
-    description = "Bypass URL redirects and open the original URL directly.",
+    description = "Adds option to bypass URL redirects and open the original URL directly.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/BypassURLRedirectsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/BypassURLRedirectsPatch.kt
@@ -17,7 +17,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 @Patch(
     name = "Bypass URL redirects",
-    description = "Adds option to bypass URL redirects and open the original URL directly.",
+    description = "Adds an option to bypass URL redirects and open the original URL directly.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Patch(
     name = "Open links externally",
-    description = "Adds option to open links outside of the app directly in your browser.",
+    description = "Adds option to always open links in your browser instead of in the in-app-browser.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube",

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Patch(
     name = "Open links externally",
-    description = "Adds option to always open links in your browser instead of in the in-app-browser.",
+    description = "Adds an option to always open links in your browser instead of in the in-app-browser.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube",

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
@@ -18,7 +18,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Patch(
     name = "Open links externally",
-    description = "Open links outside of the app directly in your browser.",
+    description = "Adds option to open links outside of the app directly in your browser.",
     compatiblePackages = [
         CompatiblePackage(
             "com.google.android.youtube",

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/MinimizedPlaybackPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/MinimizedPlaybackPatch.kt
@@ -23,7 +23,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Minimized playback",
-    description = "Enables minimized and background playback.",
+    description = "Unlocks options for picture-in-picture and background playback.",
     dependencies = [
         IntegrationsPatch::class,
         PlayerTypeHookPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Remove tracking query parameter",
-    description = "Adds option to remove the tracking info from links you share.",
+    description = "Adds an option to remove the tracking info from links you share.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Remove tracking query parameter",
-    description = "Remove the tracking query parameter from links you share.",
+    description = "Adds option to remove the tracking query parameter from links you share.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/privacy/RemoveTrackingQueryParameterPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Patch(
     name = "Remove tracking query parameter",
-    description = "Adds option to remove the tracking query parameter from links you share.",
+    description = "Adds option to remove the tracking info from links you share.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/zoomhaptics/ZoomHapticsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/zoomhaptics/ZoomHapticsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.zoomhaptics.fingerprints.ZoomHapticsFin
 
 @Patch(
     name = "Disable zoom haptics",
-    description = "Disables haptics when zooming.",
+    description = "Adds option to disable haptics when zooming.",
     dependencies = [SettingsPatch::class],
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/zoomhaptics/ZoomHapticsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/zoomhaptics/ZoomHapticsPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.youtube.misc.zoomhaptics.fingerprints.ZoomHapticsFin
 
 @Patch(
     name = "Disable zoom haptics",
-    description = "Adds option to disable haptics when zooming.",
+    description = "Adds an option to disable haptics when zooming.",
     dependencies = [SettingsPatch::class],
     compatiblePackages = [CompatiblePackage("com.google.android.youtube")]
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/video/hdrbrightness/HDRBrightnessPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/hdrbrightness/HDRBrightnessPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Patch(
     name = "HDR auto brightness",
-    description = "Adds option to make the brightness of HDR videos follow the system default.",
+    description = "Adds an option to make the brightness of HDR videos follow the system default.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/hdrbrightness/HDRBrightnessPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/hdrbrightness/HDRBrightnessPatch.kt
@@ -16,7 +16,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Patch(
     name = "HDR auto brightness",
-    description = "Makes the brightness of HDR videos follow the system default.",
+    description = "Adds option to make the brightness of HDR videos follow the system default.",
     dependencies = [IntegrationsPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
@@ -26,7 +26,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Patch(
     name = "Remember video quality",
-    description = "Adds option to remember the last video quality selected.",
+    description = "Adds an option to remember the last video quality selected.",
     dependencies = [IntegrationsPatch::class, VideoInformationPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
@@ -26,7 +26,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Patch(
     name = "Remember video quality",
-    description = "Adds option to remember and use the last video quality selected.",
+    description = "Adds option to remember the last video quality selected.",
     dependencies = [IntegrationsPatch::class, VideoInformationPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
@@ -26,7 +26,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Patch(
     name = "Remember video quality",
-    description = "Adds the ability to remember the last video quality selected.",
+    description = "Adds option to remember and use the last video quality selected.",
     dependencies = [IntegrationsPatch::class, VideoInformationPatch::class, SettingsPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/speed/PlaybackSpeedPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/speed/PlaybackSpeedPatch.kt
@@ -9,7 +9,7 @@ import app.revanced.patches.youtube.video.speed.remember.RememberPlaybackSpeedPa
 
 @Patch(
     name = "Playback speed",
-    description = "Adds custom playback speeds and ability to remember the last playback speed selected.",
+    description = "Adds options to customize available playback speeds and to remember and use the last playback speed selected.",
     dependencies = [CustomPlaybackSpeedPatch::class, RememberPlaybackSpeedPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/speed/PlaybackSpeedPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/speed/PlaybackSpeedPatch.kt
@@ -9,7 +9,7 @@ import app.revanced.patches.youtube.video.speed.remember.RememberPlaybackSpeedPa
 
 @Patch(
     name = "Playback speed",
-    description = "Adds options to customize available playback speeds and to remember and use the last playback speed selected.",
+    description = "Adds options to customize available playback speeds and to remember the last playback speed selected.",
     dependencies = [CustomPlaybackSpeedPatch::class, RememberPlaybackSpeedPatch::class],
     compatiblePackages = [
         CompatiblePackage(

--- a/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Restore old video quality menu",
-    description = "Restores the old video quality with advanced video quality options.",
+    description = "Adds option to restore the old video quality with advanced video quality options.",
     dependencies = [
         IntegrationsPatch::class,
         RestoreOldVideoQualityMenuResourcePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Restore old video quality menu",
-    description = "Adds option to restore the old video quality menu with specific video resolution options.",
+    description = "Adds an option to restore the old video quality menu with specific video resolution options.",
     dependencies = [
         IntegrationsPatch::class,
         RestoreOldVideoQualityMenuResourcePatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/videoqualitymenu/RestoreOldVideoQualityMenuPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Restore old video quality menu",
-    description = "Adds option to restore the old video quality with advanced video quality options.",
+    description = "Adds option to restore the old video quality menu with specific video resolution options.",
     dependencies = [
         IntegrationsPatch::class,
         RestoreOldVideoQualityMenuResourcePatch::class,

--- a/src/main/resources/returnyoutubedislike/host/values/strings.xml
+++ b/src/main/resources/returnyoutubedislike/host/values/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="revanced_ryd_about">About</string>
     <string name="revanced_ryd_attribution_title">ReturnYouTubeDislike.com</string>
-    <string name="revanced_ryd_attribution_summary">Data is provided by the Return YouTube Dislike API. Tap here to learn more.</string>
+    <string name="revanced_ryd_attribution_summary">Data is provided by the Return YouTube Dislike API. Tap here to learn more</string>
 
 
     <string name="revanced_ryd_statistics_category_title">ReturnYouTubeDislike API statistics of this device</string>

--- a/src/main/resources/sponsorblock/host/values/strings.xml
+++ b/src/main/resources/sponsorblock/host/values/strings.xml
@@ -53,7 +53,7 @@
     <string name="sb_api_url_changed">API URL changed</string>
     <string name="sb_settings_ie">Import/Export settings</string>
     <string name="sb_settings_copy">Copy</string>
-    <string name="sb_settings_ie_sum">Your SponsorBlock JSON configuration that can be imported/exported to ReVanced and other SponsorBlock platforms. %s</string>
+    <string name="sb_settings_ie_sum">Your SponsorBlock JSON configuration that can be imported/exported to ReVanced and other SponsorBlock platforms %s</string>
     <string name="sb_settings_ie_sum_warning">This includes your private user id. Be sure to share this wisely</string>
     <string name="sb_settings_import_successful">Settings imported successfully</string>
     <string name="sb_settings_import_failed">Failed to import: %s</string>


### PR DESCRIPTION
This PR appends `Adds an option to...` to all patches that can be toggled or customized within the patched YouTube app. 

It also aims to simplify the patch names, patch descriptions, and in-app settings to make them easier to understand for non-technical users.

Closes #1054, #740, and #2515