### PR TITLE
feat(YouTube - Theme): Add classic dark color to presets

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
@@ -59,7 +59,7 @@ object ThemeBytecodePatch : BytecodePatch(
         values = mapOf(
             "Amoled black" to AMOLED_BLACK_COLOR,
             "Material You" to "@android:color/system_neutral1_900",
-            "Old dark" to "#FF212121",
+            "Classic (old YouTube)" to "#FF212121",
             "Catppuccin (Mocha)" to "#FF181825",
             "Dark pink" to "#FF290025",
             "Dark blue" to "#FF001029",

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemeBytecodePatch.kt
@@ -59,6 +59,7 @@ object ThemeBytecodePatch : BytecodePatch(
         values = mapOf(
             "Amoled black" to AMOLED_BLACK_COLOR,
             "Material You" to "@android:color/system_neutral1_900",
+            "Old dark" to "#FF212121",
             "Catppuccin (Mocha)" to "#FF181825",
             "Dark pink" to "#FF290025",
             "Dark blue" to "#FF001029",


### PR DESCRIPTION
Add the old dark color (#212121) which was used in YT 16.xx.xx - v17.xx.xx

<img src="https://github.com/ReVanced/revanced-patches/assets/90122968/46138c5f-69dc-46dd-acf5-fb29482f1569" width=360>

Or is there a more appropriate name? I also considered the name "Dark gray"