### PR TITLE
fix(YouTube): Shorten setting titles to fit on screen

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -97,15 +97,15 @@ object HideLayoutComponentsPatch : BytecodePatch(
                 "revanced_hide_search_result_recommendations",
                 StringResource(
                     "revanced_hide_search_result_recommendations_title",
-                    "Hide search result recommendations (e.g People also watched)"
+                    "Hide search result recommendations"
                 ),
                 StringResource(
                     "revanced_hide_search_result_recommendations_summary_on",
-                    "Recommendations are hidden"
+                    "Recommendations such as People also watched are hidden"
                 ),
                 StringResource(
                     "revanced_hide_search_result_recommendations_summary_off",
-                    "Recommendations are shown"
+                    "Recommendations such as People also watched are shown"
                 )
             ),
             SwitchPreference(

--- a/src/main/resources/sponsorblock/host/values/strings.xml
+++ b/src/main/resources/sponsorblock/host/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="sb_enable_auto_hide_skip_segment_button">Automatically hide skip button</string>
     <string name="sb_enable_auto_hide_skip_segment_button_sum_on">Skip button hides after a few seconds</string>
     <string name="sb_enable_auto_hide_skip_segment_button_sum_off">Skip button displayed for entire segment</string>
-    <string name="sb_general_skiptoast">Show a toast when skipping automatically</string>
+    <string name="sb_general_skiptoast">Notify when skipping automatically</string>
     <string name="sb_general_skiptoast_sum_on">Toast is shown when a segment is automatically skipped. Tap here to see an example</string>
     <string name="sb_general_skiptoast_sum_off">Toast is not shown. Tap here to see an example</string>
     <string name="sb_general_time_without">Show video length without segments</string>


### PR DESCRIPTION
Resolves https://github.com/ReVanced/revanced-patches/issues/2576

