### PR TITLE
fix(YouTube - Spoof app version): Remove broken versions

### DIFF
--- a/src/main/resources/addresources/values/arrays.xml
+++ b/src/main/resources/addresources/values/arrays.xml
@@ -5,17 +5,11 @@
                 <item>@string/revanced_spoof_app_version_target_entry_1</item>
                 <item>@string/revanced_spoof_app_version_target_entry_2</item>
                 <item>@string/revanced_spoof_app_version_target_entry_3</item>
-                <item>@string/revanced_spoof_app_version_target_entry_4</item>
-                <item>@string/revanced_spoof_app_version_target_entry_5</item>
-                <item>@string/revanced_spoof_app_version_target_entry_6</item>
             </string-array>
             <string-array name="revanced_spoof_app_version_target_entry_values">
                 <item>18.33.40</item>
                 <item>18.20.39</item>
                 <item>18.09.39</item>
-                <item>17.08.35</item>
-                <item>16.08.35</item>
-                <item>16.01.35</item>
             </string-array>
         </patch>
         <patch id="layout.startpage.ChangeStartPagePatch">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -786,9 +786,6 @@
             <string name="revanced_spoof_app_version_target_entry_1">18.33.40 - Restore RYD Shorts incognito mode</string>
             <string name="revanced_spoof_app_version_target_entry_2">18.20.39 - Restore wide video speed &amp; quality menu</string>
             <string name="revanced_spoof_app_version_target_entry_3">18.09.39 - Restore library tab</string>
-            <string name="revanced_spoof_app_version_target_entry_4">17.08.35 - Restore old UI layout</string>
-            <string name="revanced_spoof_app_version_target_entry_5">16.08.35 - Restore explore tab</string>
-            <string name="revanced_spoof_app_version_target_entry_6">16.01.35 - Restore fewer video player action buttons</string>
         </patch>
         <patch id="layout.startpage.ChangeStartPagePatch">
             <string name="revanced_start_page_title">Set start page</string>


### PR DESCRIPTION
YouTube is disabling versions below v18 now and spoofing to these versions will break the app.

Maybe integrations can bump to newer versions, if currently users have set it below v18