### PR TITLE
fix(YouTube): Fix video playback by switching to ReVanced GmsCore vendor

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -615,6 +615,7 @@ public abstract class app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportRes
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
 	protected final fun getGmsCoreVendor ()Ljava/lang/String;
+	protected final fun getGmsCoreVendorGroupId ()Ljava/lang/String;
 }
 
 public abstract class app/revanced/patches/shared/misc/integrations/BaseIntegrationsPatch : app/revanced/patcher/patch/BytecodePatch {

--- a/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
@@ -2,12 +2,12 @@ package app.revanced.patches.music.misc.gms
 
 import app.revanced.patches.music.misc.gms.Constants.MUSIC_PACKAGE_NAME
 import app.revanced.patches.music.misc.gms.Constants.REVANCED_MUSIC_PACKAGE_NAME
-import app.revanced.patches.music.misc.gms.GmsCoreSupportResourcePatch.gmsCoreVendorOption
+import app.revanced.patches.music.misc.gms.GmsCoreSupportResourcePatch.gmsCoreVendorGroupIdOption
 import app.revanced.patches.music.misc.gms.fingerprints.*
-import app.revanced.patches.music.misc.integrations.fingerprints.ApplicationInitFingerprint
 import app.revanced.patches.music.misc.integrations.IntegrationsPatch
-import app.revanced.patches.shared.misc.gms.BaseGmsCoreSupportPatch
+import app.revanced.patches.music.misc.integrations.fingerprints.ApplicationInitFingerprint
 import app.revanced.patches.shared.fingerprints.CastContextFetchFingerprint
+import app.revanced.patches.shared.misc.gms.BaseGmsCoreSupportPatch
 
 @Suppress("unused")
 object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
@@ -32,7 +32,7 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
         PrimeMethodFingerprint,
-    )
+    ),
 ) {
-    override val gmsCoreVendor by gmsCoreVendorOption
+    override val gmsCoreVendor by gmsCoreVendorGroupIdOption
 }

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -53,15 +53,15 @@ abstract class BaseGmsCoreSupportPatch(
 ) : BytecodePatch(
     name = "GmsCore support",
     description = "Allows patched Google apps to run without root and under a different package name " +
-            "by using GmsCore instead of Google Play Services.",
+        "by using GmsCore instead of Google Play Services.",
     dependencies = setOf(
         ChangePackageNamePatch::class,
         gmsCoreSupportResourcePatch::class,
-        integrationsPatchDependency
+        integrationsPatchDependency,
     ) + dependencies,
     compatiblePackages = compatiblePackages,
     fingerprints = setOf(GmsCoreSupportFingerprint, mainActivityOnCreateFingerprint) + fingerprints,
-    requiresIntegrations = true
+    requiresIntegrations = true,
 ) {
     init {
         // Manually register all options of the resource patch so that they are visible in the patch API.
@@ -77,7 +77,7 @@ abstract class BaseGmsCoreSupportPatch(
         val transformations = arrayOf(
             ::commonTransform,
             ::contentUrisTransform,
-            packageNameTransform(fromPackageName, packageName)
+            packageNameTransform(fromPackageName, packageName),
         )
         context.transformStringReferences transform@{ string ->
             transformations.forEach { transform ->
@@ -96,7 +96,7 @@ abstract class BaseGmsCoreSupportPatch(
         // Check the availability of GmsCore.
         mainActivityOnCreateFingerprint.result?.mutableMethod?.addInstruction(
             1, // Hack to not disturb other patches (such as the integrations patch).
-            "invoke-static {}, Lapp/revanced/integrations/youtube/patches/GmsCoreSupport;->checkAvailability()V"
+            "invoke-static {}, Lapp/revanced/integrations/youtube/patches/GmsCoreSupport;->checkAvailability()V",
         ) ?: throw mainActivityOnCreateFingerprint.exception
 
         // Change the vendor of GmsCore in ReVanced Integrations.
@@ -130,8 +130,8 @@ abstract class BaseGmsCoreSupportPatch(
                     BuilderInstruction21c(
                         Opcode.CONST_STRING,
                         instruction.registerA,
-                        ImmutableStringReference(transformedString)
-                    )
+                        ImmutableStringReference(transformedString),
+                    ),
                 )
             }
         }
@@ -145,7 +145,8 @@ abstract class BaseGmsCoreSupportPatch(
             "com.google.android.gms",
             in PERMISSIONS,
             in ACTIONS,
-            in AUTHORITIES -> referencedString.replace("com.google", gmsCoreVendor!!)
+            in AUTHORITIES,
+            -> referencedString.replace("com.google", gmsCoreVendor!!)
 
             // No vendor prefix for whatever reason...
             "subscribedfeeds" -> "$gmsCoreVendor.subscribedfeeds"
@@ -161,7 +162,7 @@ abstract class BaseGmsCoreSupportPatch(
                 if (str.startsWith(uriPrefix)) {
                     return str.replace(
                         uriPrefix,
-                        "content://${authority.replace("com.google", gmsCoreVendor!!)}"
+                        "content://${authority.replace("com.google", gmsCoreVendor!!)}",
                     )
                 }
             }
@@ -174,13 +175,13 @@ abstract class BaseGmsCoreSupportPatch(
         }
 
         return null
-
     }
 
     private fun packageNameTransform(fromPackageName: String, toPackageName: String): (String) -> String? = { string ->
         when (string) {
             "$fromPackageName.SuggestionsProvider",
-            "$fromPackageName.fileprovider" -> string.replace(fromPackageName, toPackageName)
+            "$fromPackageName.fileprovider",
+            -> string.replace(fromPackageName, toPackageName)
 
             else -> null
         }
@@ -273,6 +274,9 @@ abstract class BaseGmsCoreSupportPatch(
             // fido
             "com.google.android.gms.fido.fido2.privileged.START",
 
+            // gass
+            "com.google.android.gms.gass.START",
+
             // games
             "com.google.android.gms.games.service.START",
             "com.google.android.gms.games.PLAY_GAMES_UPGRADE",
@@ -292,8 +296,18 @@ abstract class BaseGmsCoreSupportPatch(
             // misc
             "com.google.android.gms.gmscompliance.service.START",
             "com.google.android.gms.oss.licenses.service.START",
+            "com.google.android.gms.tapandpay.service.BIND",
+            "com.google.android.gms.measurement.START",
+            "com.google.android.gms.languageprofile.service.START",
+            "com.google.android.gms.clearcut.service.START",
+            "com.google.android.gms.icing.LIGHTWEIGHT_INDEX_SERVICE",
+
+            // potoken
+            "com.google.android.gms.potokens.service.START",
+
+            // droidguard/ safetynet
+            "com.google.android.gms.droidguard.service.START",
             "com.google.android.gms.safetynet.service.START",
-            "com.google.android.gms.tapandpay.service.BIND"
         )
 
         /**
@@ -314,7 +328,7 @@ abstract class BaseGmsCoreSupportPatch(
             "com.google.android.gms.fonts",
 
             // phenotype
-            "com.google.android.gms.phenotype"
+            "com.google.android.gms.phenotype",
         )
     }
 

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -27,10 +27,9 @@ abstract class BaseGmsCoreSupportResourcePatch(
     internal val gmsCoreVendorOption =
         stringPatchOption(
             key = "gmsCoreVendor",
-            default = "com.mgoogle",
+            default = "app.revanced",
             values =
             mapOf(
-                "Vanced" to "com.mgoogle",
                 "ReVanced" to "app.revanced",
             ),
             title = "GmsCore Vendor",

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -39,7 +39,7 @@ abstract class BaseGmsCoreSupportResourcePatch(
             required = true,
         ) { it!!.matches(Regex("^[a-z]\\w*(\\.[a-z]\\w*)+\$")) }
 
-    protected val gmsCoreVendor by gmsCoreVendorOption
+    protected var gmsCoreVendor by gmsCoreVendorOption
 
     override fun execute(context: ResourceContext) {
         AddResourcesPatch(BaseGmsCoreSupportResourcePatch::class)
@@ -47,8 +47,8 @@ abstract class BaseGmsCoreSupportResourcePatch(
         // TODO: Remove this, once ReVanced Manager supports falling back to default patch option values,
         //  once a patch option value has been removed from a patch.
         // The vendor Vanced is known to break with ReVanced. Fall back to ReVanced as the vendor.
-        if (gmsCoreVendorOption.value == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
-            gmsCoreVendorOption.value = gmsCoreVendorOption.default
+        if (gmsCoreVendor == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
+            gmsCoreVendor = gmsCoreVendorOption.default
         }
 
         context.patchManifest()

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -8,6 +8,7 @@ import app.revanced.patches.all.misc.packagename.ChangePackageNamePatch
 import app.revanced.patches.all.misc.resources.AddResourcesPatch
 import org.w3c.dom.Element
 import org.w3c.dom.Node
+import java.util.logging.Logger
 
 private const val OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE = "com.mgoogle"
 
@@ -46,8 +47,11 @@ abstract class BaseGmsCoreSupportResourcePatch(
 
         // TODO: Remove this, once ReVanced Manager supports falling back to default patch option values,
         //  once a patch option value has been removed from a patch.
-        // The vendor Vanced is known to break with ReVanced. Fall back to ReVanced as the vendor.
         if (gmsCoreVendor == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
+            Logger.getLogger(name).info(
+                "Vanced MicroG is incompatible with ReVanced. Falling back to ReVanced GmsCore.",
+            )
+
             gmsCoreVendor = gmsCoreVendorOption.default
         }
 

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -10,8 +10,6 @@ import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.util.logging.Logger
 
-private const val OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE = "com.mgoogle"
-
 /**
  * Abstract resource patch that allows Google apps to run without root and under a different package name
  * by using GmsCore instead of Google Play Services.
@@ -27,6 +25,10 @@ abstract class BaseGmsCoreSupportResourcePatch(
     private val spoofedPackageSignature: String,
     dependencies: Set<PatchClass> = setOf(),
 ) : ResourcePatch(dependencies = setOf(ChangePackageNamePatch::class, AddResourcesPatch::class) + dependencies) {
+    private companion object {
+        private const val VANCED_VENDOR = "com.mgoogle"
+        private const val PACKAGE_NAME_REGEX_PATTERN = "^[a-z]\\w*(\\.[a-z]\\w*)+\$"
+    }
     internal val gmsCoreVendorOption =
         stringPatchOption(
             key = "gmsCoreVendor",
@@ -38,7 +40,7 @@ abstract class BaseGmsCoreSupportResourcePatch(
             title = "GmsCore Vendor",
             description = "The group id of the GmsCore vendor.",
             required = true,
-        ) { it!!.matches(Regex("^[a-z]\\w*(\\.[a-z]\\w*)+\$")) }
+        ) { it!!.matches(Regex(PACKAGE_NAME_REGEX_PATTERN)) }
 
     protected var gmsCoreVendor by gmsCoreVendorOption
 
@@ -47,7 +49,7 @@ abstract class BaseGmsCoreSupportResourcePatch(
 
         // TODO: Remove this, once ReVanced Manager supports falling back to default patch option values,
         //  once a patch option value has been removed from a patch.
-        if (gmsCoreVendor == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
+        if (gmsCoreVendor!!.lowercase().startsWith(VANCED_VENDOR)) {
             Logger.getLogger(name).info(
                 "Vanced MicroG is incompatible with ReVanced. Falling back to ReVanced GmsCore.",
             )

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -48,7 +48,8 @@ abstract class BaseGmsCoreSupportResourcePatch(
         // This could be done in the option validation, but that shows
         // a warning message the user might interpret as something went wrong.
         // So instead silently use the updated default value.
-        // TODO: Remove this temporary logic (and also revert the `gms_core_not_running_warning` string change)
+        // TODO: Remove this temporary logic after Manager improves handling of changed default options.
+        // (and also revert the `gms_core_not_running_warning` string change)
         if (gmsCoreVendorOption.value == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
             gmsCoreVendorOption.value = gmsCoreVendorOption.default
             // If there was patch logging, it would be useful here.

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -39,6 +39,9 @@ abstract class BaseGmsCoreSupportResourcePatch(
 
     protected val gmsCoreVendorGroupId by gmsCoreVendorGroupIdOption
 
+    @Deprecated("Use gmsCoreVendorGroupId instead.", ReplaceWith("gmsCoreVendorGroupId"))
+    protected val gmsCoreVendor by gmsCoreVendorGroupIdOption
+
     override fun execute(context: ResourceContext) {
         AddResourcesPatch(BaseGmsCoreSupportResourcePatch::class)
 

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -25,10 +25,8 @@ abstract class BaseGmsCoreSupportResourcePatch(
     private val spoofedPackageSignature: String,
     dependencies: Set<PatchClass> = setOf(),
 ) : ResourcePatch(dependencies = setOf(ChangePackageNamePatch::class, AddResourcesPatch::class) + dependencies) {
-    private companion object {
-        private const val VANCED_VENDOR = "com.mgoogle"
-        private const val PACKAGE_NAME_REGEX_PATTERN = "^[a-z]\\w*(\\.[a-z]\\w*)+\$"
-    }
+    private val logger = Logger.getLogger(name)
+
     internal val gmsCoreVendorOption =
         stringPatchOption(
             key = "gmsCoreVendor",
@@ -50,9 +48,7 @@ abstract class BaseGmsCoreSupportResourcePatch(
         // TODO: Remove this, once ReVanced Manager supports falling back to default patch option values,
         //  once a patch option value has been removed from a patch.
         if (gmsCoreVendor!!.lowercase().startsWith(VANCED_VENDOR)) {
-            Logger.getLogger(name).info(
-                "Vanced MicroG is incompatible with ReVanced. Falling back to ReVanced GmsCore.",
-            )
+            logger.info("Vanced MicroG is incompatible with ReVanced. Falling back to ReVanced GmsCore.")
 
             gmsCoreVendor = gmsCoreVendorOption.default
         }
@@ -130,5 +126,10 @@ abstract class BaseGmsCoreSupportResourcePatch(
                 "<package android:name=\"$gmsCoreVendor.android.gms\"/></queries>",
             ),
         )
+    }
+
+    private companion object {
+        private const val VANCED_VENDOR = "com.mgoogle"
+        private const val PACKAGE_NAME_REGEX_PATTERN = "^[a-z]\\w*(\\.[a-z]\\w*)+\$"
     }
 }

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -44,15 +44,11 @@ abstract class BaseGmsCoreSupportResourcePatch(
     override fun execute(context: ResourceContext) {
         AddResourcesPatch(BaseGmsCoreSupportResourcePatch::class)
 
-        // Ignore old Vanced MicroG options, if the patch options are from an old Manager/CLI installation.
-        // This could be done in the option validation, but that shows
-        // a warning message the user might interpret as something went wrong.
-        // So instead silently use the updated default value.
-        // TODO: Remove this temporary logic after Manager improves handling of changed default options.
-        // (and also revert the `gms_core_not_running_warning` string change)
+        // TODO: Remove this, once ReVanced Manager supports falling back to default patch option values,
+        //  once a patch option value has been removed from a patch.
+        // The vendor Vanced is known to break with ReVanced. Fall back to ReVanced as the vendor.
         if (gmsCoreVendorOption.value == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
             gmsCoreVendorOption.value = gmsCoreVendorOption.default
-            // If there was patch logging, it would be useful here.
         }
 
         context.patchManifest()

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -9,6 +9,8 @@ import app.revanced.patches.all.misc.resources.AddResourcesPatch
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 
+private const val OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE = "com.mgoogle"
+
 /**
  * Abstract resource patch that allows Google apps to run without root and under a different package name
  * by using GmsCore instead of Google Play Services.
@@ -41,6 +43,16 @@ abstract class BaseGmsCoreSupportResourcePatch(
 
     override fun execute(context: ResourceContext) {
         AddResourcesPatch(BaseGmsCoreSupportResourcePatch::class)
+
+        // Ignore old Vanced MicroG options, if the patch options are from an old Manager/CLI installation.
+        // This could be done in the option validation, but that shows
+        // a warning message the user might interpret as something went wrong.
+        // So instead silently use the updated default value.
+        // TODO: Remove this temporary logic (and also revert the `gms_core_not_running_warning` string change)
+        if (gmsCoreVendorOption.value == OBSOLETE_VANCED_MICROG_PATCH_OPTION_VALUE) {
+            gmsCoreVendorOption.value = gmsCoreVendorOption.default
+            // If there was patch logging, it would be useful here.
+        }
 
         context.patchManifest()
         context.addSpoofingMetadata()

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/ClientSpoofPatch.kt
@@ -18,8 +18,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
     name = "Client spoof",
-    description = "Adds options to spoof the client to allow video playback.",
-    dependencies = [SpoofSignaturePatch::class],
+    description = "Spoofs the client to allow video playback.",
     compatiblePackages = [
         CompatiblePackage("com.google.android.youtube"),
     ],

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignaturePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/SpoofSignaturePatch.kt
@@ -13,21 +13,11 @@ import app.revanced.patches.shared.misc.settings.preference.PreferenceScreen
 import app.revanced.patches.shared.misc.settings.preference.PreferenceScreen.Sorting
 import app.revanced.patches.shared.misc.settings.preference.SwitchPreference
 import app.revanced.patches.youtube.misc.fix.playback.fingerprints.*
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.ParamsMapPutFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.PlayerResponseModelImplGeneralFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.PlayerResponseModelImplLiveStreamFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.PlayerResponseModelImplRecommendedLevelFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.ScrubbedPreviewLayoutFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.StoryboardRendererDecoderRecommendedLevelFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.StoryboardRendererDecoderSpecFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.StoryboardRendererSpecFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.StoryboardThumbnailFingerprint
-import app.revanced.patches.youtube.misc.fix.playback.fingerprints.StoryboardThumbnailParentFingerprint
 import app.revanced.patches.youtube.misc.playertype.PlayerTypeHookPatch
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import app.revanced.patches.youtube.video.information.VideoInformationPatch
 import app.revanced.patches.youtube.video.playerresponse.PlayerResponseMethodHookPatch
-import app.revanced.util.*
+import app.revanced.util.exception
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
@@ -43,6 +33,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
         AddResourcesPatch::class,
     ],
 )
+@Deprecated("This patch will be removed in the future.")
 object SpoofSignaturePatch : BytecodePatch(
     setOf(
         PlayerResponseModelImplGeneralFingerprint,

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
@@ -6,11 +6,10 @@ import app.revanced.patches.youtube.layout.buttons.cast.HideCastButtonPatch
 import app.revanced.patches.youtube.misc.fix.playback.ClientSpoofPatch
 import app.revanced.patches.youtube.misc.gms.Constants.REVANCED_YOUTUBE_PACKAGE_NAME
 import app.revanced.patches.youtube.misc.gms.Constants.YOUTUBE_PACKAGE_NAME
-import app.revanced.patches.youtube.misc.gms.GmsCoreSupportResourcePatch.gmsCoreVendorOption
+import app.revanced.patches.youtube.misc.gms.GmsCoreSupportResourcePatch.gmsCoreVendorGroupIdOption
 import app.revanced.patches.youtube.misc.gms.fingerprints.*
 import app.revanced.patches.youtube.misc.integrations.IntegrationsPatch
 import app.revanced.patches.youtube.shared.fingerprints.HomeActivityFingerprint
-
 
 @Suppress("unused")
 object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
@@ -22,18 +21,19 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         GooglePlayUtilityFingerprint,
         CastDynamiteModuleFingerprint,
         CastDynamiteModuleV2Fingerprint,
-        CastContextFetchFingerprint
+        CastContextFetchFingerprint,
     ),
     mainActivityOnCreateFingerprint = HomeActivityFingerprint,
     integrationsPatchDependency = IntegrationsPatch::class,
     dependencies = setOf(
         HideCastButtonPatch::class,
-        ClientSpoofPatch::class
+        ClientSpoofPatch::class,
     ),
     gmsCoreSupportResourcePatch = GmsCoreSupportResourcePatch,
     compatiblePackages = setOf(
         CompatiblePackage(
-            "com.google.android.youtube", setOf(
+            "com.google.android.youtube",
+            setOf(
                 "18.48.39",
                 "18.49.37",
                 "19.01.34",
@@ -44,9 +44,9 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
                 "19.06.39",
                 "19.07.40",
                 "19.08.36",
-                "19.09.37"
-            )
-        )
+                "19.09.37",
+            ),
+        ),
     ),
     fingerprints = setOf(
         ServiceCheckFingerprint,
@@ -55,7 +55,7 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
         PrimeMethodFingerprint,
-    )
+    ),
 ) {
-    override val gmsCoreVendor by gmsCoreVendorOption
+    override val gmsCoreVendor by gmsCoreVendorGroupIdOption
 }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportResourcePatch.kt
@@ -8,12 +8,11 @@ import app.revanced.patches.youtube.misc.gms.Constants.REVANCED_YOUTUBE_PACKAGE_
 import app.revanced.patches.youtube.misc.gms.Constants.YOUTUBE_PACKAGE_NAME
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
 
-
 object GmsCoreSupportResourcePatch : BaseGmsCoreSupportResourcePatch(
     fromPackageName = YOUTUBE_PACKAGE_NAME,
     toPackageName = REVANCED_YOUTUBE_PACKAGE_NAME,
     spoofedPackageSignature = "24bb24c05e47e0aefa68a58a766179d9b613a600",
-    dependencies = setOf(SettingsPatch::class, AddResourcesPatch::class)
+    dependencies = setOf(SettingsPatch::class, AddResourcesPatch::class),
 ) {
     override fun execute(context: ResourceContext) {
         AddResourcesPatch(this::class)
@@ -22,9 +21,9 @@ object GmsCoreSupportResourcePatch : BaseGmsCoreSupportResourcePatch(
             IntentPreference(
                 "microg_settings",
                 intent = IntentPreference.Intent("", "org.microg.gms.ui.SettingsActivity") {
-                    "$gmsCoreVendor.android.gms"
-                }
-            )
+                    "$gmsCoreVendorGroupId.android.gms"
+                },
+            ),
         )
 
         super.execute(context)

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -13,11 +13,7 @@
             <string name="revanced_settings_import_failure_parse">Import failed: %s</string>
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
-            <!-- Temporarily use an 'update' message, to handle migrating users from Vanced MicroG -->
-            <string name="gms_core_not_installed_warning">GmsCore is outdated. Please update it.</string>
-            <!-- TODO: change back to this string
             <string name="gms_core_not_installed_warning">GmsCore is not installed. Please install.</string>
-            -->
             <string name="gms_core_not_running_warning">GmsCore is failing to run. Please follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -13,7 +13,11 @@
             <string name="revanced_settings_import_failure_parse">Import failed: %s</string>
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
+            <!-- Temporarily use an 'update' message, to handle migrating users from Vanced MicroG -->
+            <string name="gms_core_not_installed_warning">GmsCore is outdated. Please update it.</string>
+            <!-- TODO: change back to this string
             <string name="gms_core_not_installed_warning">GmsCore is not installed. Please install.</string>
+            -->
             <string name="gms_core_not_running_warning">GmsCore is failing to run. Please follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>


### PR DESCRIPTION
# About

This PR switches to the ReVanced GmsCore vendor to fix playback issues. The previous vendor did not update GmsCore, resulting in missing features required for playback, specifically PoToken, which was added to requests recently. Because the PoToken was missing, playback failed.

Related:

- https://github.com/microg/GmsCore/issues/1870
- https://github.com/microg/GmsCore/issues/2253

Fixes #293

# Todo

- [x] Implement migration code or a dialog for `com.mgoogle`

Depends on:

- https://github.com/ReVanced/GmsCore/pull/2