### PR TITLE
feat(YouTube - GmsCore): Require ignoring battery optimizations

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -648,8 +648,8 @@ public final class app/revanced/patches/shared/misc/fix/verticalscroll/VerticalS
 }
 
 public abstract class app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch : app/revanced/patcher/patch/BytecodePatch {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }

--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -648,8 +648,8 @@ public final class app/revanced/patches/shared/misc/fix/verticalscroll/VerticalS
 }
 
 public abstract class app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch : app/revanced/patcher/patch/BytecodePatch {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Ljava/util/Set;Lapp/revanced/patcher/fingerprint/MethodFingerprint;Lkotlin/reflect/KClass;Lapp/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }

--- a/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
@@ -34,5 +34,5 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         PrimeMethodFingerprint,
     ),
 ) {
-    override val gmsCoreVendor by gmsCoreVendorGroupIdOption
+    override val gmsCoreVendorGroupId by gmsCoreVendorGroupIdOption
 }

--- a/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
@@ -21,8 +21,7 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
     ),
-    launchActivityOnCreateFingerprint = ApplicationInitFingerprint,
-    mainActivityOnCreateFingerprint = ApplicationInitFingerprint, // FIXME this needs a YT Music specific fingerprint
+    mainActivityOnCreateFingerprint = ApplicationInitFingerprint,
     integrationsPatchDependency = IntegrationsPatch::class,
     gmsCoreSupportResourcePatch = GmsCoreSupportResourcePatch,
     compatiblePackages = setOf(CompatiblePackage("com.google.android.apps.youtube.music")),

--- a/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
@@ -21,7 +21,8 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
     ),
-    mainActivityOnCreateFingerprint = ApplicationInitFingerprint,
+    launchActivityOnCreateFingerprint = ApplicationInitFingerprint,
+    mainActivityOnCreateFingerprint = ApplicationInitFingerprint, // FIXME this needs a YT Music specific fingerprint
     integrationsPatchDependency = IntegrationsPatch::class,
     gmsCoreSupportResourcePatch = GmsCoreSupportResourcePatch,
     compatiblePackages = setOf(CompatiblePackage("com.google.android.apps.youtube.music")),

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -101,7 +101,7 @@ abstract class BaseGmsCoreSupportPatch(
         mainActivityOnCreateFingerprint.result?.mutableMethod?.addInstructions(
             1, // Hack to not disturb other patches (such as the YTMusic integrations patch).
             "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->" +
-                "checkGmsCore(Landroid/app/Activity;)V",
+                "checkGmsCore(Landroid/content/Context;)V",
         ) ?: throw mainActivityOnCreateFingerprint.exception
 
         // Change the vendor of GmsCore in ReVanced Integrations.

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -33,7 +33,6 @@ import com.android.tools.smali.dexlib2.util.MethodUtil
  * @param primeMethodFingerprint The fingerprint of the "prime" method that needs to be patched.
  * @param earlyReturnFingerprints The fingerprints of methods that need to be returned early.
  * @param mainActivityOnCreateFingerprint The fingerprint of the main activity onCreate method.
- *                                        This activity must be suitable to show a dialog with.
  * @param integrationsPatchDependency The patch responsible for the integrations.
  * @param gmsCoreSupportResourcePatch The corresponding resource patch that is used to patch the resources.
  * @param dependencies Additional dependencies of this patch.

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -99,7 +99,7 @@ abstract class BaseGmsCoreSupportPatch(
 
         // Verify GmsCore is installed and whitelisted for power optimizations and background usage.
         mainActivityOnCreateFingerprint.result?.mutableMethod?.addInstructions(
-            0, // Insert at the start, because p0 is overwrote before the super call.
+            1, // Hack to not disturb other patches (such as the YTMusic integrations patch).
             "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->" +
                 "checkGmsCore(Landroid/app/Activity;)V",
         ) ?: throw mainActivityOnCreateFingerprint.exception

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -12,7 +12,7 @@ import app.revanced.patches.shared.misc.gms.BaseGmsCoreSupportPatch.Constants.AC
 import app.revanced.patches.shared.misc.gms.BaseGmsCoreSupportPatch.Constants.AUTHORITIES
 import app.revanced.patches.shared.misc.gms.BaseGmsCoreSupportPatch.Constants.PERMISSIONS
 import app.revanced.patches.shared.misc.gms.fingerprints.GmsCoreSupportFingerprint
-import app.revanced.patches.shared.misc.gms.fingerprints.GmsCoreSupportFingerprint.GET_GMS_CORE_VENDOR_METHOD_NAME
+import app.revanced.patches.shared.misc.gms.fingerprints.GmsCoreSupportFingerprint.GET_GMS_CORE_VENDOR_GROUP_ID_METHOD_NAME
 import app.revanced.util.exception
 import app.revanced.util.getReference
 import app.revanced.util.returnEarly
@@ -68,7 +68,7 @@ abstract class BaseGmsCoreSupportPatch(
         gmsCoreSupportResourcePatch.options.values.forEach(options::register)
     }
 
-    internal abstract val gmsCoreVendor: String?
+    internal abstract val gmsCoreVendorGroupId: String?
 
     override fun execute(context: BytecodeContext) {
         val packageName = ChangePackageNamePatch.setOrGetFallbackPackageName(toPackageName)
@@ -101,8 +101,8 @@ abstract class BaseGmsCoreSupportPatch(
 
         // Change the vendor of GmsCore in ReVanced Integrations.
         GmsCoreSupportFingerprint.result?.mutableClass?.methods
-            ?.single { it.name == GET_GMS_CORE_VENDOR_METHOD_NAME }
-            ?.replaceInstruction(0, "const-string v0, \"$gmsCoreVendor\"")
+            ?.single { it.name == GET_GMS_CORE_VENDOR_GROUP_ID_METHOD_NAME }
+            ?.replaceInstruction(0, "const-string v0, \"$gmsCoreVendorGroupId\"")
             ?: throw GmsCoreSupportFingerprint.exception
     }
 
@@ -146,10 +146,10 @@ abstract class BaseGmsCoreSupportPatch(
             in PERMISSIONS,
             in ACTIONS,
             in AUTHORITIES,
-            -> referencedString.replace("com.google", gmsCoreVendor!!)
+            -> referencedString.replace("com.google", gmsCoreVendorGroupId!!)
 
             // No vendor prefix for whatever reason...
-            "subscribedfeeds" -> "$gmsCoreVendor.subscribedfeeds"
+            "subscribedfeeds" -> "$gmsCoreVendorGroupId.subscribedfeeds"
             else -> null
         }
 
@@ -162,7 +162,7 @@ abstract class BaseGmsCoreSupportPatch(
                 if (str.startsWith(uriPrefix)) {
                     return str.replace(
                         uriPrefix,
-                        "content://${authority.replace("com.google", gmsCoreVendor!!)}",
+                        "content://${authority.replace("com.google", gmsCoreVendorGroupId!!)}",
                     )
                 }
             }
@@ -170,7 +170,7 @@ abstract class BaseGmsCoreSupportPatch(
             // gms also has a 'subscribedfeeds' authority, check for that one too
             val subFeedsUriPrefix = "content://subscribedfeeds"
             if (str.startsWith(subFeedsUriPrefix)) {
-                return str.replace(subFeedsUriPrefix, "content://$gmsCoreVendor.subscribedfeeds")
+                return str.replace(subFeedsUriPrefix, "content://$gmsCoreVendorGroupId.subscribedfeeds")
             }
         }
 

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportPatch.kt
@@ -64,7 +64,11 @@ abstract class BaseGmsCoreSupportPatch(
         integrationsPatchDependency,
     ) + dependencies,
     compatiblePackages = compatiblePackages,
-    fingerprints = setOf(GmsCoreSupportFingerprint, launchActivityOnCreateFingerprint, mainActivityOnCreateFingerprint) + fingerprints,
+    fingerprints = setOf(
+        GmsCoreSupportFingerprint,
+        launchActivityOnCreateFingerprint,
+        mainActivityOnCreateFingerprint,
+    ) + fingerprints,
     requiresIntegrations = true,
 ) {
     init {
@@ -97,19 +101,21 @@ abstract class BaseGmsCoreSupportPatch(
         // Return these methods early to prevent the app from crashing.
         earlyReturnFingerprints.toList().returnEarly()
 
-        // Verify Gms is installed.  Cannot be done in main activity as the app will crash before then.
+        // Verify GmsCore is installed.  Cannot be done in main activity as the app will crash before then.
         launchActivityOnCreateFingerprint.result?.mutableMethod?.addInstruction(
             0,
-            "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->checkGmsInstalled(Landroid/app/Activity;)V",
+            "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->" +
+                "checkGmsCoreInstalled(Landroid/app/Activity;)V",
         ) ?: throw launchActivityOnCreateFingerprint.exception
 
-        // Verify Gms is whitelisted for power optimizations and background usage.
+        // Verify GmsCore is whitelisted for power optimizations and background usage.
         // Must use a different hook because a dialog is shown and the launch activity context is not suitable for that.
         mainActivityOnCreateFingerprint.result?.mutableMethod?.addInstructions(
             // p0 is changed before the call to superclass method.
             // to keep this simple call into integrations first.
-            1, // Insert after Gms installation check.
-            "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->checkGmsWhitelisted(Landroid/app/Activity;)V",
+            1, // Insert after GmsCore installation check.
+            "invoke-static/range { p0 .. p0 }, Lapp/revanced/integrations/shared/GmsCoreSupport;->" +
+                "checkGmsCoreWhitelisted(Landroid/app/Activity;)V",
         ) ?: throw mainActivityOnCreateFingerprint.exception
 
         // Change the vendor of GmsCore in ReVanced Integrations.

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportResourcePatch.kt
@@ -121,7 +121,6 @@ abstract class BaseGmsCoreSupportResourcePatch(
     }
 
     private companion object {
-        private const val VANCED_VENDOR = "com.mgoogle"
         private const val PACKAGE_NAME_REGEX_PATTERN = "^[a-z]\\w*(\\.[a-z]\\w*)+\$"
     }
 }

--- a/src/main/kotlin/app/revanced/patches/shared/misc/gms/fingerprints/GmsCoreSupportFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/gms/fingerprints/GmsCoreSupportFingerprint.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.fingerprint.MethodFingerprint
 internal object GmsCoreSupportFingerprint : MethodFingerprint(
     customFingerprint = { _, classDef ->
         classDef.type.endsWith("GmsCoreSupport;")
-    }
+    },
 ) {
-    const val GET_GMS_CORE_VENDOR_METHOD_NAME = "getGmsCoreVendor"
+    const val GET_GMS_CORE_VENDOR_GROUP_ID_METHOD_NAME = "getGmsCoreVendorGroupId"
 }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -34,7 +34,7 @@ object AnnouncementsPatch : BytecodePatch(
         MainActivityOnCreateFingerprint.resultOrThrow().mutableMethod.addInstructions(
             // Insert index must be great than the insert index used by GmsCoreSupport,
             // as both patch the same method, and Announcements needs to check if
-            // Gms is not installed and skip fetching the announcement.
+            // Gms is not installed to skip fetching the announcement.
             1,
             "invoke-static/range { p0 .. p0 }, $INTEGRATIONS_CLASS_DESCRIPTOR->showAnnouncement(Landroid/app/Activity;)V"
         )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -2,16 +2,13 @@ package app.revanced.patches.youtube.misc.announcements
 
 import app.revanced.patcher.data.BytecodeContext
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
-import app.revanced.patcher.extensions.InstructionExtensions.getInstructions
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.annotation.CompatiblePackage
 import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.patches.all.misc.resources.AddResourcesPatch
 import app.revanced.patches.shared.misc.settings.preference.SwitchPreference
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
-import app.revanced.patches.youtube.shared.fingerprints.MainActivityFingerprint
 import app.revanced.patches.youtube.shared.fingerprints.MainActivityOnCreateFingerprint
-import app.revanced.util.exception
 import app.revanced.util.resultOrThrow
 
 @Patch(
@@ -35,7 +32,10 @@ object AnnouncementsPatch : BytecodePatch(
         )
 
         MainActivityOnCreateFingerprint.resultOrThrow().mutableMethod.addInstructions(
-            0,
+            // Insert index must be great than the insert index used by GmsCoreSupport,
+            // as both patch the same method, and Announcements needs to check if
+            // Gms is not installed and skip fetching the announcement.
+            1,
             "invoke-static/range { p0 .. p0 }, $INTEGRATIONS_CLASS_DESCRIPTOR->showAnnouncement(Landroid/app/Activity;)V"
         )
     }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -33,8 +33,7 @@ object AnnouncementsPatch : BytecodePatch(
 
         MainActivityOnCreateFingerprint.resultOrThrow().mutableMethod.addInstructions(
             // Insert index must be great than the insert index used by GmsCoreSupport,
-            // as both patch the same method, and Announcements needs to check if
-            // Gms is not installed to skip fetching the announcement.
+            // as both patch the same method and GmsCore check should be first.
             1,
             "invoke-static/range { p0 .. p0 }, $INTEGRATIONS_CLASS_DESCRIPTOR->showAnnouncement(Landroid/app/Activity;)V"
         )

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/announcements/AnnouncementsPatch.kt
@@ -10,8 +10,9 @@ import app.revanced.patches.all.misc.resources.AddResourcesPatch
 import app.revanced.patches.shared.misc.settings.preference.SwitchPreference
 import app.revanced.patches.youtube.misc.settings.SettingsPatch
 import app.revanced.patches.youtube.shared.fingerprints.MainActivityFingerprint
+import app.revanced.patches.youtube.shared.fingerprints.MainActivityOnCreateFingerprint
 import app.revanced.util.exception
-import com.android.tools.smali.dexlib2.Opcode
+import app.revanced.util.resultOrThrow
 
 @Patch(
     name = "Announcements",
@@ -21,7 +22,7 @@ import com.android.tools.smali.dexlib2.Opcode
 )
 @Suppress("unused")
 object AnnouncementsPatch : BytecodePatch(
-    setOf(MainActivityFingerprint)
+    setOf(MainActivityOnCreateFingerprint)
 ) {
     private const val INTEGRATIONS_CLASS_DESCRIPTOR =
         "Lapp/revanced/integrations/youtube/patches/announcements/AnnouncementsPatch;"
@@ -33,16 +34,9 @@ object AnnouncementsPatch : BytecodePatch(
             SwitchPreference("revanced_announcements")
         )
 
-        val onCreateMethod = MainActivityFingerprint.result?.let {
-            it.mutableClass.methods.find { method -> method.name == "onCreate" }
-        } ?: throw MainActivityFingerprint.exception
-
-        val superCallIndex = onCreateMethod.getInstructions().indexOfFirst { it.opcode == Opcode.INVOKE_SUPER_RANGE }
-
-        onCreateMethod.addInstructions(
-            superCallIndex + 1,
-            "invoke-static { v1 }, $INTEGRATIONS_CLASS_DESCRIPTOR->showAnnouncement(Landroid/app/Activity;)V"
+        MainActivityOnCreateFingerprint.resultOrThrow().mutableMethod.addInstructions(
+            0,
+            "invoke-static/range { p0 .. p0 }, $INTEGRATIONS_CLASS_DESCRIPTOR->showAnnouncement(Landroid/app/Activity;)V"
         )
-
     }
 }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
@@ -57,5 +57,5 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         PrimeMethodFingerprint,
     ),
 ) {
-    override val gmsCoreVendor by gmsCoreVendorGroupIdOption
+    override val gmsCoreVendorGroupId by gmsCoreVendorGroupIdOption
 }

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
@@ -9,7 +9,6 @@ import app.revanced.patches.youtube.misc.gms.Constants.YOUTUBE_PACKAGE_NAME
 import app.revanced.patches.youtube.misc.gms.GmsCoreSupportResourcePatch.gmsCoreVendorGroupIdOption
 import app.revanced.patches.youtube.misc.gms.fingerprints.*
 import app.revanced.patches.youtube.misc.integrations.IntegrationsPatch
-import app.revanced.patches.youtube.shared.fingerprints.HomeActivityFingerprint
 import app.revanced.patches.youtube.shared.fingerprints.MainActivityOnCreateFingerprint
 
 @Suppress("unused")
@@ -24,7 +23,6 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
     ),
-    launchActivityOnCreateFingerprint = HomeActivityFingerprint,
     mainActivityOnCreateFingerprint = MainActivityOnCreateFingerprint,
     integrationsPatchDependency = IntegrationsPatch::class,
     dependencies = setOf(

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/gms/GmsCoreSupportPatch.kt
@@ -10,6 +10,7 @@ import app.revanced.patches.youtube.misc.gms.GmsCoreSupportResourcePatch.gmsCore
 import app.revanced.patches.youtube.misc.gms.fingerprints.*
 import app.revanced.patches.youtube.misc.integrations.IntegrationsPatch
 import app.revanced.patches.youtube.shared.fingerprints.HomeActivityFingerprint
+import app.revanced.patches.youtube.shared.fingerprints.MainActivityOnCreateFingerprint
 
 @Suppress("unused")
 object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
@@ -23,7 +24,8 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
         CastDynamiteModuleV2Fingerprint,
         CastContextFetchFingerprint,
     ),
-    mainActivityOnCreateFingerprint = HomeActivityFingerprint,
+    launchActivityOnCreateFingerprint = HomeActivityFingerprint,
+    mainActivityOnCreateFingerprint = MainActivityOnCreateFingerprint,
     integrationsPatchDependency = IntegrationsPatch::class,
     dependencies = setOf(
         HideCastButtonPatch::class,

--- a/src/main/kotlin/app/revanced/patches/youtube/shared/fingerprints/MainActivityOnCreateFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/shared/fingerprints/MainActivityOnCreateFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.youtube.shared.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+internal object MainActivityOnCreateFingerprint : MethodFingerprint(
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;"),
+    customFingerprint = { methodDef, classDef ->
+        methodDef.name == "onCreate" &&
+        (classDef.type.endsWith("MainActivity;")
+                // Old versions of YouTube called this class "WatchWhileActivity" instead.
+                || classDef.type.endsWith("WatchWhileActivity;"))
+    }
+)

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -14,7 +14,9 @@
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
             <string name="gms_core_not_installed_warning">GmsCore is not installed. Install it.</string>
-            <string name="gms_core_not_whitelisted_warning">Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_whitelisted_title">You need to change your device settings</string>
+            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">Your GmsCore is not whitelisted from battery optimization.\n\nTo fix this, follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">Your GmsCore is not allowed to run in the background.\n\nTo fix this, follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -15,9 +15,11 @@
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
             <string name="gms_core_dialog_title">Action needed</string>
             <string name="gms_core_dialog_ok_button_text">Open website</string>
-            <string name="gms_core_not_installed_message">GmsCore is not installed.\n\nTap to open the website to install.</string>
-            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
-            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_not_installed_message">GmsCore is not installed.\n\nTap to open the website to install.</string>
+            <string name="gms_core_dialog_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_toast_not_installed_message">GmsCore is not installed. Install it.</string>
+            <string name="gms_core_toast_not_whitelisted_message">Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -16,7 +16,7 @@
             <string name="gms_core_toast_not_installed_message">GmsCore is not installed. Install it.</string>
             <string name="gms_core_toast_not_whitelisted_message">Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
             <string name="gms_core_dialog_title">Action needed</string>
-            <string name="gms_core_dialog_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted from battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
             <string name="gms_core_dialog_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
             <string name="gms_core_dialog_ok_button_text">Open website</string>
         </patch>

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -13,13 +13,12 @@
             <string name="revanced_settings_import_failure_parse">Import failed: %s</string>
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
-            <string name="gms_core_dialog_title">Action needed</string>
-            <string name="gms_core_dialog_ok_button_text">Open website</string>
-            <string name="gms_core_dialog_not_installed_message">GmsCore is not installed.\n\nTap to open the website to install.</string>
-            <string name="gms_core_dialog_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
-            <string name="gms_core_dialog_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
             <string name="gms_core_toast_not_installed_message">GmsCore is not installed. Install it.</string>
             <string name="gms_core_toast_not_whitelisted_message">Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_title">Action needed</string>
+            <string name="gms_core_dialog_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_dialog_ok_button_text">Open website</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -885,6 +885,7 @@
             <string name="revanced_announcements_summary_off">Announcements are not shown on startup</string>
             <string name="revanced_announcements_enabled_summary">Show announcements on startup</string>
             <string name="revanced_announcements_connection_failed">Failed connecting to announcements provider</string>
+            <string name="revanced_announcements_dialog_dismiss">Dismiss</string>
         </patch>
         <patch id="misc.autorepeat.AutoRepeatPatch">
             <string name="revanced_auto_repeat_title">Enable auto-repeat</string>

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -14,9 +14,9 @@
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
             <string name="gms_core_not_installed_warning">GmsCore is not installed. Install it.</string>
-            <string name="gms_core_not_whitelisted_title">You need to change your device settings</string>
-            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">Your GmsCore is not whitelisted from battery optimization.\n\nTo fix this, follow the \"Don\'t kill my app\" guide for GmsCore.</string>
-            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">Your GmsCore is not allowed to run in the background.\n\nTo fix this, follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_whitelisted_title">Action needed</string>
+            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted from battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.\n\nClick \"Ok\" to open it.</string>
+            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">GmsCore is can't run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.\n\nClick \"Ok\" to open it.</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -14,7 +14,7 @@
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
             <string name="gms_core_not_installed_warning">GmsCore is not installed. Install it.</string>
-            <string name="gms_core_not_whitelisted_warning">GmsCore is not whitelisted from battery optimizations. Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_whitelisted_warning">Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -13,10 +13,11 @@
             <string name="revanced_settings_import_failure_parse">Import failed: %s</string>
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
-            <string name="gms_core_not_installed_warning">GmsCore is not installed. Install it.</string>
-            <string name="gms_core_not_whitelisted_title">Action needed</string>
-            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted from battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.\n\nClick \"Ok\" to open it.</string>
-            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">GmsCore is can't run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.\n\nClick \"Ok\" to open it.</string>
+            <string name="gms_core_dialog_title">Action needed</string>
+            <string name="gms_core_dialog_ok_button_text">Open website</string>
+            <string name="gms_core_not_installed_message">GmsCore is not installed.\n\nTap to open the website to install.</string>
+            <string name="gms_core_not_whitelisted_using_battery_optimizations_message">GmsCore is not whitelisted for battery optimization.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_whitelisted_not_allowed_in_background_message">GmsCore does not have permission to run in the background.\n\nFollow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>
     <app id="youtube">

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -13,8 +13,8 @@
             <string name="revanced_settings_import_failure_parse">Import failed: %s</string>
         </patch>
         <patch id="misc.gms.BaseGmsCoreSupportResourcePatch">
-            <string name="gms_core_not_installed_warning">GmsCore is not installed. Please install.</string>
-            <string name="gms_core_not_running_warning">GmsCore is failing to run. Please follow the \"Don\'t kill my app\" guide for GmsCore.</string>
+            <string name="gms_core_not_installed_warning">GmsCore is not installed. Install it.</string>
+            <string name="gms_core_not_whitelisted_warning">GmsCore is not whitelisted from battery optimizations. Follow the \"Don\'t kill my app\" guide for GmsCore.</string>
         </patch>
     </app>
     <app id="youtube">


### PR DESCRIPTION
# About

This PR requests the user to disable or ignore battery optimizations for GmsCore. This is necessary to prevent playback from failing when GmsCore is killed in the background. It is also a suggested action by GmsCore itself.

One bug that I have been observing for a while is that, for some reason, the app is not correctly killed with `System.exit(0)`. This causes spam; for example, in WSA this launches the website multiple times repeatedly in an infinite loop. Offtopic though.

RE: https://github.com/ReVanced/revanced-integrations/pull/599