### PR TITLE
fix(Tumblr): Restore compatibility with latest versions 

### DIFF
--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/fingerprints/ShowGiftMessagePopupFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/popups/fingerprints/ShowGiftMessagePopupFingerprint.kt
@@ -1,9 +1,12 @@
 package app.revanced.patches.tumblr.annoyances.popups.fingerprints
 
+import app.revanced.patcher.extensions.or
 import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
 
 // This method is responsible for loading and displaying the visual Layout of the Gift Message Popup.
 internal object ShowGiftMessagePopupFingerprint : MethodFingerprint(
-    strings = listOf("activity", "anchorView"),
-    customFingerprint = { methodDef, _ -> methodDef.definingClass.endsWith("GiftMessagePopup;") }
+    strings = listOf("activity", "anchorView", "textMessage"),
+    returnType = "V",
+    accessFlags = AccessFlags.FINAL or AccessFlags.PUBLIC
 )

--- a/src/main/kotlin/app/revanced/patches/tumblr/featureflags/fingerprints/GetFeatureValueFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/featureflags/fingerprints/GetFeatureValueFingerprint.kt
@@ -1,6 +1,8 @@
 package app.revanced.patches.tumblr.featureflags.fingerprints
 
+import app.revanced.patcher.extensions.or
 import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
 // This fingerprint targets the method to get the value of a Feature in the class "com.tumblr.configuration.Feature".
@@ -19,5 +21,7 @@ internal object GetFeatureValueFingerprint : MethodFingerprint(
         Opcode.INVOKE_STATIC,
         Opcode.MOVE_RESULT
     ),
-    customFingerprint = { method, _ -> method.definingClass == "Lcom/tumblr/configuration/Configuration;" }
+    returnType = "Ljava/lang/String;",
+    parameters = listOf("L", "Z"),
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL
 )

--- a/src/main/kotlin/app/revanced/patches/tumblr/live/DisableTumblrLivePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/live/DisableTumblrLivePatch.kt
@@ -8,11 +8,11 @@ import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
 import app.revanced.patches.tumblr.timelinefilter.TimelineFilterPatch
 
 @Patch(
-    name = "Disable Tumblr Live",
     description = "Disable the Tumblr Live tab button and dashboard carousel.",
     dependencies = [OverrideFeatureFlagsPatch::class, TimelineFilterPatch::class],
     compatiblePackages = [CompatiblePackage("com.tumblr")],
 )
+@Deprecated("Tumblr Live was removed and is no longer served in the feed, making this patch useless.")
 @Suppress("unused")
 object DisableTumblrLivePatch : BytecodePatch(emptySet()) {
     override fun execute(context: BytecodeContext) {


### PR DESCRIPTION
Due to more classes getting obfuscated in new app versions, two patches had to be fixed:
- fixed feature flags patch & fingerprint
- fixed gift message popup fingerprint

Due to the removal of Tumblr Live, the Disable Tumblr Live Patch is obsolete
- deprecated disable tumblr live patch