### PR TITLE
feat(Amazon): Add `Always allow deep-linking` patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -152,6 +152,12 @@ public final class app/revanced/patches/all/telephony/sim/spoof/SpoofSimCountryP
 	public fun transform (Lapp/revanced/patcher/util/proxy/mutableTypes/MutableMethod;Lkotlin/Pair;)V
 }
 
+public final class app/revanced/patches/amazon/deeplinking/DeepLinkingPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/amazon/deeplinking/DeepLinkingPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/backdrops/misc/pro/ProUnlockPatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/backdrops/misc/pro/ProUnlockPatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingFingerprint.kt
@@ -1,0 +1,11 @@
+package app.revanced.patches.amazon.deeplinking
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object DeepLinkingFingerprint : MethodFingerprint(
+    "Z",
+    parameters = listOf("L"),
+    accessFlags = AccessFlags.PRIVATE.value,
+    strings = listOf("https://www.", "android.intent.action.VIEW")
+)

--- a/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
@@ -8,7 +8,7 @@ import app.revanced.patcher.patch.annotation.Patch
 
 @Patch(
     name = "Always allow deep-linking",
-    description = "Always allow deep-linking",
+    description = "Allows the Amazon app to open Amazon links, even if it is not the default link handler for Amazon domains.",
     compatiblePackages = [CompatiblePackage("com.amazon.mShop.android.shopping")]
 )
 @Suppress("unused")

--- a/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
@@ -8,7 +8,7 @@ import app.revanced.patcher.patch.annotation.Patch
 
 @Patch(
     name = "Always allow deep-linking",
-    description = "Allows the Amazon app to open Amazon links, even if it is not the default link handler for Amazon domains.",
+    description = "Open Amazon links, even if the app is not set to handle Amazon links.",
     compatiblePackages = [CompatiblePackage("com.amazon.mShop.android.shopping")]
 )
 @Suppress("unused")

--- a/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
@@ -1,0 +1,27 @@
+package app.revanced.patches.amazon.deeplinking
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+
+@Patch(
+    name = "Always allow deep-linking",
+    description = "Always allow deep-linking",
+    compatiblePackages = [CompatiblePackage("com.amazon.mShop.android.shopping")]
+)
+@Suppress("unused")
+object DeepLinkingPatch : BytecodePatch(
+    setOf(DeepLinkingFingerprint)
+) {
+    override fun execute(context: BytecodeContext) {
+        DeepLinkingFingerprint.result!!.mutableMethod.addInstructions(
+            0,
+            """
+                const/4 v0, 0x1
+                return v0
+            """
+        )
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/amazon/deeplinking/DeepLinkingPatch.kt
@@ -5,6 +5,7 @@ import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.annotation.CompatiblePackage
 import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.util.exception
 
 @Patch(
     name = "Always allow deep-linking",
@@ -16,12 +17,12 @@ object DeepLinkingPatch : BytecodePatch(
     setOf(DeepLinkingFingerprint)
 ) {
     override fun execute(context: BytecodeContext) {
-        DeepLinkingFingerprint.result!!.mutableMethod.addInstructions(
+        DeepLinkingFingerprint.result?.mutableMethod?.addInstructions(
             0,
             """
                 const/4 v0, 0x1
                 return v0
             """
-        )
+        ) ?: throw DeepLinkingFingerprint.exception
     }
 }


### PR DESCRIPTION
Amazon's mobile app (`com.amazon.mShop.android.shopping`) disables its deep-linking activity in certain cases (when it is not set to open its links by default), preventing it from being launched even via an explicit Intent.

This patch removes that restriction.