### PR TITLE
feat(Twitter): Add `Sanitize sharing links` patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -1200,6 +1200,12 @@ public final class app/revanced/patches/twitter/misc/links/OpenLinksWithAppChoos
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/vsco/misc/pro/UnlockProPatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/vsco/misc/pro/UnlockProPatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/src/main/kotlin/app/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch.kt
@@ -1,0 +1,29 @@
+package app.revanced.patches.twitter.misc.links
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.twitter.misc.links.fingerprints.SanitizeSharingLinksFingerprint
+import app.revanced.util.exception
+
+@Patch(
+    name = "Sanitize sharing links",
+    description = "Removes the tracking query parameters from links before they are shared.",
+    compatiblePackages = [CompatiblePackage("com.twitter.android")],
+)
+object SanitizeSharingLinksPatch : BytecodePatch(
+    setOf(SanitizeSharingLinksFingerprint),
+) {
+    override fun execute(context: BytecodeContext) {
+        SanitizeSharingLinksFingerprint.result?.mutableMethod?.addInstructions(
+            0,
+            """
+                # Method takes in a link (string, param 0) and then appends the tracking query params,
+                # so all we need to do is return back the passed-in string
+                return-object p0
+            """,
+        ) ?: throw SanitizeSharingLinksFingerprint.exception
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/twitter/misc/links/fingerprints/SanitizeSharingLinksFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/links/fingerprints/SanitizeSharingLinksFingerprint.kt
@@ -1,0 +1,8 @@
+package app.revanced.patches.twitter.misc.links.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+internal object SanitizeSharingLinksFingerprint : MethodFingerprint(
+    strings = listOf("<this>", "shareParam", "sessionToken"),
+    returnType = "Ljava/lang/String;",
+)


### PR DESCRIPTION
The Twitter (X) app appends some tracking query parameters to shared links, this patch removes them.  
From decompiler, before:
![image](https://github.com/ReVanced/revanced-patches/assets/23278147/a1d68a49-dbd2-462e-ac86-9b10098118fc)
After:
![image](https://github.com/ReVanced/revanced-patches/assets/23278147/9458eb62-14f9-42e1-b1db-10fc3d954c15)
