### PR TITLE
feat: Add `Hex` patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -28,6 +28,12 @@ public final class app/revanced/patches/all/misc/debugging/EnableAndroidDebuggin
 	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
 }
 
+public final class app/revanced/patches/all/misc/hex/HexPatch : app/revanced/patcher/patch/RawResourcePatch {
+	public static final field INSTANCE Lapp/revanced/patches/all/misc/hex/HexPatch;
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
+}
+
 public final class app/revanced/patches/all/misc/network/OverrideCertificatePinningPatch : app/revanced/patcher/patch/ResourcePatch {
 	public static final field INSTANCE Lapp/revanced/patches/all/misc/network/OverrideCertificatePinningPatch;
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V

--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -28,10 +28,8 @@ public final class app/revanced/patches/all/misc/debugging/EnableAndroidDebuggin
 	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
 }
 
-public final class app/revanced/patches/all/misc/hex/HexPatch : app/revanced/patcher/patch/RawResourcePatch {
-	public static final field INSTANCE Lapp/revanced/patches/all/misc/hex/HexPatch;
-	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
-	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
+public final class app/revanced/patches/all/misc/hex/HexPatch : app/revanced/patches/shared/misc/hex/BaseHexPatch {
+	public fun <init> ()V
 }
 
 public final class app/revanced/patches/all/misc/network/OverrideCertificatePinningPatch : app/revanced/patcher/patch/ResourcePatch {
@@ -673,6 +671,21 @@ public abstract class app/revanced/patches/shared/misc/gms/BaseGmsCoreSupportRes
 	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
 	protected final fun getGmsCoreVendor ()Ljava/lang/String;
 	protected final fun getGmsCoreVendorGroupId ()Ljava/lang/String;
+}
+
+public abstract class app/revanced/patches/shared/misc/hex/BaseHexPatch : app/revanced/patcher/patch/RawResourcePatch {
+	public fun <init> ()V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
+}
+
+public final class app/revanced/patches/shared/misc/hex/BaseHexPatch$Replacement {
+	public static final field Companion Lapp/revanced/patches/shared/misc/hex/BaseHexPatch$Replacement$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun replacePattern ([B)V
+}
+
+public final class app/revanced/patches/shared/misc/hex/BaseHexPatch$Replacement$Companion {
 }
 
 public abstract class app/revanced/patches/shared/misc/integrations/BaseIntegrationsPatch : app/revanced/patcher/patch/BytecodePatch {

--- a/src/main/kotlin/app/revanced/patches/all/misc/hex/HexPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/misc/hex/HexPatch.kt
@@ -1,0 +1,143 @@
+package app.revanced.patches.all.misc.hex
+
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.PatchException
+import app.revanced.patcher.patch.RawResourcePatch
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patcher.patch.options.PatchOption.PatchExtensions.registerNewPatchOption
+import app.revanced.patcher.patch.options.PatchOption.PatchExtensions.stringPatchOption
+import app.revanced.patches.all.misc.hex.HexPatch.Replacement.Companion.replacementOf
+import app.revanced.util.Utils.trimIndentMultiline
+import kotlin.math.max
+
+@Patch(
+    name = "Hex",
+    description = "Replaces a hexadecimal patterns of bytes of files in an APK.",
+    use = false,
+)
+@Suppress("unused")
+object HexPatch : RawResourcePatch() {
+    private val targetFilePath by stringPatchOption(
+        key = "targetFilePath",
+        default = null,
+        title = "Target file path",
+        description = "The path to the file to make the changes in relative to the APK root.",
+        required = true,
+    )
+
+    // TODO: Instead of stringArrayOption, use a custom option type to work around
+    //  https://github.com/ReVanced/revanced-library/issues/48.
+    //  Replace the custom option type with a stringArrayOption once the issue is resolved.
+    private val patterns by registerNewPatchOption<app.revanced.patcher.patch.Patch<*>, List<String>>(
+        key = "patterns",
+        default = null,
+        title = "patterns",
+        description = """
+            Hexadecimal patterns to search for and replace in the target file.
+            
+            A pattern is a sequence of case insensitive strings representing hexadecimal bytes separated by spaces.
+            An example pattern is 'aa 01 02 FF'.
+
+            Every pattern must be followed by a pipe ('|') and the replacement pattern.
+            The replacement pattern must have the same length as the original pattern.
+
+            Full example of a valid input:
+            'aa 01 02 FF|00 00 00 00'
+        """.trimIndentMultiline(),
+        required = true,
+        valueType = "StringArray",
+    )
+
+    override fun execute(context: ResourceContext) {
+        val targetFile = context[targetFilePath!!, true]
+        // TODO: Use a file channel to read and write the file instead of reading the whole file into memory,
+        //  in order to reduce memory usage.
+        val targetFileBytes = targetFile.readBytes()
+
+        patterns!!.map(::replacementOf).forEach { replacement ->
+            replacement.replacePattern(targetFileBytes)
+        }
+
+        targetFile.writeBytes(targetFileBytes)
+    }
+
+    private class Replacement private constructor(pattern: String, replacementPattern: String) {
+        val pattern = pattern.toByteArrayPattern()
+        val replacementPattern = replacementPattern.toByteArrayPattern()
+
+        init {
+            if (this.pattern.size != this.replacementPattern.size) {
+                throw PatchException("Pattern and replacement pattern must have the same length: $pattern")
+            }
+        }
+
+        fun replacePattern(haystack: ByteArray) {
+            val startIndex = indexOfPatternIn(haystack)
+
+            if (startIndex == -1) {
+                throw PatchException("Pattern not found in target file: $pattern")
+            }
+
+            replacementPattern.copyInto(haystack, startIndex, 0, replacementPattern.size)
+        }
+
+        // TODO: Allow searching in a file channel instead of a byte array to reduce memory usage.
+        /**
+         * Returns the index of the first occurrence of [pattern] in the haystack
+         * using the Boyer-Moore algorithm.
+         *
+         * @param haystack The array to search in.
+         *
+         * @return The index of the first occurrence of the [pattern] in the haystack or -1
+         * if the [pattern] is not found.
+         */
+        private fun indexOfPatternIn(haystack: ByteArray): Int {
+            val needle = pattern
+
+            val haystackLength = haystack.size - 1
+            val needleLength = needle.size - 1
+            val right = IntArray(256) { -1 }
+
+            for (i in 0 until needleLength) right[needle[i].toInt()] = i
+
+            var skip: Int
+            for (i in 0..haystackLength - needleLength) {
+                skip = 0
+
+                for (j in needleLength - 1 downTo 0)
+                    if (needle[j] != haystack[i + j]) {
+                        skip = max(1, j - right[haystack[i + j].toInt()])
+
+                        break
+                    }
+
+                if (skip == 0) return i
+            }
+            return -1
+        }
+
+        companion object {
+            private fun String.toByteArrayPattern() = try {
+                split(" ").map { it.toByte(16) }.toByteArray()
+            } catch (e: NumberFormatException) {
+                throw PatchException(
+                    "Could not parse pattern: $this.  A pattern is a sequence of case insensitive strings " +
+                        "representing hexadecimal bytes separated by spaces",
+                )
+            }
+
+            fun replacementOf(patternAndReplacement: String): Replacement {
+                val (pattern, replacementPattern) = try {
+                    patternAndReplacement.split("|")
+                } catch (e: Exception) {
+                    throw PatchException(
+                        "Invalid pattern: $patternAndReplacement. " +
+                            "Every pattern must be followed by a pipe ('|') and the replacement pattern",
+                    )
+                }
+
+                return Replacement(pattern, replacementPattern)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/all/misc/hex/HexPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/misc/hex/HexPatch.kt
@@ -1,14 +1,11 @@
 package app.revanced.patches.all.misc.hex
 
-import app.revanced.patcher.data.ResourceContext
 import app.revanced.patcher.patch.PatchException
-import app.revanced.patcher.patch.RawResourcePatch
 import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.patcher.patch.options.PatchOption.PatchExtensions.registerNewPatchOption
-import app.revanced.patcher.patch.options.PatchOption.PatchExtensions.stringPatchOption
-import app.revanced.patches.all.misc.hex.HexPatch.Replacement.Companion.replacementOf
+import app.revanced.patches.shared.misc.hex.BaseHexPatch
 import app.revanced.util.Utils.trimIndentMultiline
-import kotlin.math.max
+import app.revanced.patcher.patch.Patch as PatchClass
 
 @Patch(
     name = "Hex",
@@ -16,128 +13,43 @@ import kotlin.math.max
     use = false,
 )
 @Suppress("unused")
-object HexPatch : RawResourcePatch() {
-    private val targetFilePath by stringPatchOption(
-        key = "targetFilePath",
-        default = null,
-        title = "Target file path",
-        description = "The path to the file to make the changes in relative to the APK root.",
-        required = true,
-    )
-
+class HexPatch : BaseHexPatch() {
     // TODO: Instead of stringArrayOption, use a custom option type to work around
     //  https://github.com/ReVanced/revanced-library/issues/48.
     //  Replace the custom option type with a stringArrayOption once the issue is resolved.
-    private val patterns by registerNewPatchOption<app.revanced.patcher.patch.Patch<*>, List<String>>(
-        key = "patterns",
-        default = null,
-        title = "patterns",
+    private val replacementsOption by registerNewPatchOption<PatchClass<*>, List<String>>(
+        key = "replacements",
+        title = "replacements",
         description = """
-            Hexadecimal patterns to search for and replace in the target file.
+            Hexadecimal patterns to search for and replace with another in a target file.
             
-            A pattern is a sequence of case insensitive strings representing hexadecimal bytes separated by spaces.
+            A pattern is a sequence of case insensitive strings, each representing hexadecimal bytes, separated by spaces.
             An example pattern is 'aa 01 02 FF'.
 
-            Every pattern must be followed by a pipe ('|') and the replacement pattern.
+            Every pattern must be followed by a pipe ('|'), the replacement pattern,
+            another pipe ('|'), and the path to the file to make the changes in relative to the APK root. 
             The replacement pattern must have the same length as the original pattern.
 
             Full example of a valid input:
-            'aa 01 02 FF|00 00 00 00'
+            'aa 01 02 FF|00 00 00 00|path/to/file'
         """.trimIndentMultiline(),
         required = true,
         valueType = "StringArray",
     )
 
-    override fun execute(context: ResourceContext) {
-        val targetFile = context[targetFilePath!!, true]
-        // TODO: Use a file channel to read and write the file instead of reading the whole file into memory,
-        //  in order to reduce memory usage.
-        val targetFileBytes = targetFile.readBytes()
-
-        patterns!!.map(::replacementOf).forEach { replacement ->
-            replacement.replacePattern(targetFileBytes)
-        }
-
-        targetFile.writeBytes(targetFileBytes)
-    }
-
-    private class Replacement private constructor(pattern: String, replacementPattern: String) {
-        val pattern = pattern.toByteArrayPattern()
-        val replacementPattern = replacementPattern.toByteArrayPattern()
-
-        init {
-            if (this.pattern.size != this.replacementPattern.size) {
-                throw PatchException("Pattern and replacement pattern must have the same length: $pattern")
-            }
-        }
-
-        fun replacePattern(haystack: ByteArray) {
-            val startIndex = indexOfPatternIn(haystack)
-
-            if (startIndex == -1) {
-                throw PatchException("Pattern not found in target file: $pattern")
-            }
-
-            replacementPattern.copyInto(haystack, startIndex, 0, replacementPattern.size)
-        }
-
-        // TODO: Allow searching in a file channel instead of a byte array to reduce memory usage.
-        /**
-         * Returns the index of the first occurrence of [pattern] in the haystack
-         * using the Boyer-Moore algorithm.
-         *
-         * @param haystack The array to search in.
-         *
-         * @return The index of the first occurrence of the [pattern] in the haystack or -1
-         * if the [pattern] is not found.
-         */
-        private fun indexOfPatternIn(haystack: ByteArray): Int {
-            val needle = pattern
-
-            val haystackLength = haystack.size - 1
-            val needleLength = needle.size - 1
-            val right = IntArray(256) { -1 }
-
-            for (i in 0 until needleLength) right[needle[i].toInt()] = i
-
-            var skip: Int
-            for (i in 0..haystackLength - needleLength) {
-                skip = 0
-
-                for (j in needleLength - 1 downTo 0)
-                    if (needle[j] != haystack[i + j]) {
-                        skip = max(1, j - right[haystack[i + j].toInt()])
-
-                        break
-                    }
-
-                if (skip == 0) return i
-            }
-            return -1
-        }
-
-        companion object {
-            private fun String.toByteArrayPattern() = try {
-                split(" ").map { it.toByte(16) }.toByteArray()
-            } catch (e: NumberFormatException) {
+    override val replacements
+        get() = replacementsOption!!.map { from ->
+            val (pattern, replacementPattern, targetFilePath) = try {
+                from.split("|", limit = 3)
+            } catch (e: Exception) {
                 throw PatchException(
-                    "Could not parse pattern: $this.  A pattern is a sequence of case insensitive strings " +
-                        "representing hexadecimal bytes separated by spaces",
+                    "Invalid input: $from.\n" +
+                        "Every pattern must be followed by a pipe ('|'), " +
+                        "the replacement pattern, another pipe ('|'), " +
+                        "and the path to the file to make the changes in relative to the APK root. ",
                 )
             }
 
-            fun replacementOf(patternAndReplacement: String): Replacement {
-                val (pattern, replacementPattern) = try {
-                    patternAndReplacement.split("|")
-                } catch (e: Exception) {
-                    throw PatchException(
-                        "Invalid pattern: $patternAndReplacement. " +
-                            "Every pattern must be followed by a pipe ('|') and the replacement pattern",
-                    )
-                }
-
-                return Replacement(pattern, replacementPattern)
-            }
+            Replacement(pattern, replacementPattern, targetFilePath)
         }
-    }
 }

--- a/src/main/kotlin/app/revanced/patches/shared/misc/hex/BaseHexPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/hex/BaseHexPatch.kt
@@ -1,0 +1,120 @@
+package app.revanced.patches.shared.misc.hex
+
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.PatchException
+import app.revanced.patcher.patch.RawResourcePatch
+import kotlin.math.max
+
+abstract class BaseHexPatch : RawResourcePatch() {
+    internal abstract val replacements: List<Replacement>
+
+    override fun execute(context: ResourceContext) {
+        replacements.groupBy { it.targetFilePath }.forEach { (targetFilePath, replacements) ->
+            val targetFile = try {
+                context[targetFilePath, true]
+            } catch (e: Exception) {
+                throw PatchException("Could not find target file: $targetFilePath")
+            }
+
+            // TODO: Use a file channel to read and write the file instead of reading the whole file into memory,
+            //  in order to reduce memory usage.
+            val targetFileBytes = targetFile.readBytes()
+
+            replacements.forEach { replacement ->
+                replacement.replacePattern(targetFileBytes)
+            }
+
+            targetFile.writeBytes(targetFileBytes)
+        }
+    }
+
+    /**
+     * Represents a pattern to search for and its replacement pattern.
+     *
+     * @property pattern The pattern to search for.
+     * @property replacementPattern The pattern to replace the [pattern] with.
+     * @property targetFilePath The path to the file to make the changes in relative to the APK root.
+     */
+    class Replacement(
+        pattern: String,
+        replacementPattern: String,
+        internal val targetFilePath: String,
+    ) {
+        private val pattern = pattern.toByteArrayPattern()
+        private val replacementPattern = replacementPattern.toByteArrayPattern()
+
+        init {
+            if (this.pattern.size != this.replacementPattern.size) {
+                throw PatchException("Pattern and replacement pattern must have the same length: $pattern")
+            }
+        }
+
+        /**
+         * Replaces the [pattern] with the [replacementPattern] in the [targetFileBytes].
+         *
+         * @param targetFileBytes The bytes of the file to make the changes in.
+         */
+        fun replacePattern(targetFileBytes: ByteArray) {
+            val startIndex = indexOfPatternIn(targetFileBytes)
+
+            if (startIndex == -1) {
+                throw PatchException("Pattern not found in target file: $pattern")
+            }
+
+            replacementPattern.copyInto(targetFileBytes, startIndex, 0, replacementPattern.size)
+        }
+
+        // TODO: Allow searching in a file channel instead of a byte array to reduce memory usage.
+        /**
+         * Returns the index of the first occurrence of [pattern] in the haystack
+         * using the Boyer-Moore algorithm.
+         *
+         * @param haystack The array to search in.
+         *
+         * @return The index of the first occurrence of the [pattern] in the haystack or -1
+         * if the [pattern] is not found.
+         */
+        private fun indexOfPatternIn(haystack: ByteArray): Int {
+            val needle = pattern
+
+            val haystackLength = haystack.size - 1
+            val needleLength = needle.size - 1
+            val right = IntArray(256) { -1 }
+
+            for (i in 0 until needleLength) right[needle[i].toInt().and(0xFF)] = i
+
+            var skip: Int
+            for (i in 0..haystackLength - needleLength) {
+                skip = 0
+
+                for (j in needleLength - 1 downTo 0)
+                    if (needle[j] != haystack[i + j]) {
+                        skip = max(1, j - right[haystack[i + j].toInt().and(0xFF)])
+
+                        break
+                    }
+
+                if (skip == 0) return i
+            }
+            return -1
+        }
+
+        companion object {
+            /**
+             * Convert a string representing a pattern of hexadecimal bytes to a byte array.
+             *
+             * @return The byte array representing the pattern.
+             * @throws PatchException If the pattern is invalid.
+             */
+            private fun String.toByteArrayPattern() = try {
+                split(" ").map { it.toInt(16).toByte() }.toByteArray()
+            } catch (e: NumberFormatException) {
+                throw PatchException(
+                    "Could not parse pattern: $this.  A pattern is a sequence of case insensitive strings " +
+                        "representing hexadecimal bytes separated by spaces",
+                    e,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/shared/misc/hex/BaseHexPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/shared/misc/hex/BaseHexPatch.kt
@@ -36,21 +36,21 @@ abstract class BaseHexPatch : RawResourcePatch() {
      * @property targetFilePath The path to the file to make the changes in relative to the APK root.
      */
     class Replacement(
-        pattern: String,
+        private val pattern: String,
         replacementPattern: String,
         internal val targetFilePath: String,
     ) {
-        private val pattern = pattern.toByteArrayPattern()
+        private val patternBytes = pattern.toByteArrayPattern()
         private val replacementPattern = replacementPattern.toByteArrayPattern()
 
         init {
-            if (this.pattern.size != this.replacementPattern.size) {
+            if (this.patternBytes.size != this.replacementPattern.size) {
                 throw PatchException("Pattern and replacement pattern must have the same length: $pattern")
             }
         }
 
         /**
-         * Replaces the [pattern] with the [replacementPattern] in the [targetFileBytes].
+         * Replaces the [patternBytes] with the [replacementPattern] in the [targetFileBytes].
          *
          * @param targetFileBytes The bytes of the file to make the changes in.
          */
@@ -61,21 +61,21 @@ abstract class BaseHexPatch : RawResourcePatch() {
                 throw PatchException("Pattern not found in target file: $pattern")
             }
 
-            replacementPattern.copyInto(targetFileBytes, startIndex, 0, replacementPattern.size)
+            replacementPattern.copyInto(targetFileBytes, startIndex)
         }
 
         // TODO: Allow searching in a file channel instead of a byte array to reduce memory usage.
         /**
-         * Returns the index of the first occurrence of [pattern] in the haystack
+         * Returns the index of the first occurrence of [patternBytes] in the haystack
          * using the Boyer-Moore algorithm.
          *
          * @param haystack The array to search in.
          *
-         * @return The index of the first occurrence of the [pattern] in the haystack or -1
-         * if the [pattern] is not found.
+         * @return The index of the first occurrence of the [patternBytes] in the haystack or -1
+         * if the [patternBytes] is not found.
          */
         private fun indexOfPatternIn(haystack: ByteArray): Int {
-            val needle = pattern
+            val needle = patternBytes
 
             val haystackLength = haystack.size - 1
             val needleLength = needle.size - 1


### PR DESCRIPTION
# About

This PR adds a patch to make replacements given a byte pattern in an APK path with another byte pattern. It'll be the basis for other patches that need replacements in native binaries, for example.

# Todo

- [ ] ~~Currently, the patch reads the target file to memory, which is inefficient. Ideally, a file channel could be used for memory-critical situations.~~ Would require creating small buffers in which the pattern is searched, but that involves more complex implementations
- [ ] ~~An issue that has been discovered is that array patch options break on ReVanced CLI due to a bug in the Json serializer to parse the options from the options Json file. That issue is currently worked around in this patch but could cause issues in ReVanced Manager. This has to be tested.~~ This needs to be solved outside of this PR
-  [x] Currently, this patch is standalone, so other patches can't really depend on it to make fixed hex patches