### PR TITLE
feat(Spotify): Add `Unlock Spotify Premium` patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -965,6 +965,10 @@ public final class app/revanced/patches/spotify/navbar/PremiumNavbarTabResourceP
 	public fun execute (Lapp/revanced/patcher/data/ResourceContext;)V
 }
 
+public final class app/revanced/patches/spotify/premium/UnlockPremiumPatch : app/revanced/patches/shared/misc/hex/BaseHexPatch {
+	public fun <init> ()V
+}
+
 public final class app/revanced/patches/strava/subscription/UnlockSubscriptionPatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/strava/subscription/UnlockSubscriptionPatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/src/main/kotlin/app/revanced/patches/spotify/premium/UnlockPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/premium/UnlockPremiumPatch.kt
@@ -1,0 +1,42 @@
+package app.revanced.patches.spotify.premium
+
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.shared.misc.hex.BaseHexPatch
+
+@Patch(
+    name = "Unlock Spotify Premium",
+    description = "Unlock Spotify Premium features for ARM64 devices. " +
+        "Server-sided features like downloading songs are still locked. ",
+    compatiblePackages = [
+        CompatiblePackage(
+            "com.spotify.music",
+            [
+                "8.9.8.545",
+            ],
+        ),
+    ],
+)
+@Suppress("unused")
+class UnlockPremiumPatch : BaseHexPatch() {
+    private val arm64Replacements = listOf(
+        Replacement(
+            "01 0a 2a 89 00 00 34",
+            "01 0a 2a 1f 20 03 d5",
+            "lib/arm64-v8a/liborbit-jni-spotify.so",
+        ),
+        Replacement(
+            "94 1f 31 00 71 81 00 00 54",
+            "94 1f 31 00 71 04 00 00 14",
+            "lib/arm64-v8a/liborbit-jni-spotify.so",
+        ),
+        Replacement(
+            "e1 01 00 54 20",
+            "0f 00 00 14 20",
+            "lib/arm64-v8a/liborbit-jni-spotify.so",
+        ),
+    )
+
+    // To support other architectures, add replacements for them.
+    override val replacements = arm64Replacements
+}


### PR DESCRIPTION
# About

This PR adds a patch for Spotify to enable Spotify Premium by patching a native binary using a raw resource patch.
The question would be whether this patch should be merged, given that it's a patch to unlock Spotify Premium.