### PR TITLE
fix(YouTube Music - Remove upgrade button): Fix compatibility with latest versions

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/fingerprints/PivotBarConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/fingerprints/PivotBarConstructorFingerprint.kt
@@ -13,6 +13,7 @@ internal object PivotBarConstructorFingerprint : MethodFingerprint(
         Opcode.CHECK_CAST,
         Opcode.INVOKE_INTERFACE,
         Opcode.GOTO,
+        Opcode.NOP,
         Opcode.IPUT_OBJECT,
         Opcode.RETURN_VOID,
     ),


### PR DESCRIPTION
Fixes #2984.