### PR TITLE
feat(tumblr): add disable ad-free banner patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -1062,6 +1062,12 @@ public final class app/revanced/patches/tumblr/ads/DisableDashboardAds : app/rev
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/tumblr/annoyances/DisableAdFreeBannerPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/tumblr/annoyances/DisableAdFreeBannerPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/src/main/kotlin/app/revanced/patches/tumblr/annoyances/adfree/DisableAdFreeBannerPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tumblr/annoyances/adfree/DisableAdFreeBannerPatch.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.tumblr.annoyances.adfree
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.tumblr.featureflags.OverrideFeatureFlagsPatch
+
+@Patch(
+    name = "Disable Ad-Free Banner",
+    description = "Disables the Frog Banner prompting you to buy Tumblr Ad-Free",
+    dependencies = [OverrideFeatureFlagsPatch::class],
+    compatiblePackages = [CompatiblePackage("com.tumblr")],
+)
+@Suppress("unused")
+object DisableAdFreeBannerPatch : BytecodePatch(emptySet()) {
+    override fun execute(context: BytecodeContext) {
+        // Disable the "AD_FREE_CTA_BANNER" ("Whether or not to show ad free prompt") feature flag.
+        OverrideFeatureFlagsPatch.addOverride("adFreeCtaBanner", "false")
+    }
+}


### PR DESCRIPTION
Every once in a while, a Bottom Sheet popup will appear, encouraging the user to buy Tumblr's Ad-Free subscription.
![image](https://github.com/ReVanced/revanced-patches/assets/29953391/5f085f7b-9f2a-43b6-9413-179b53c12a4b)
We simply disable this popup by overwriting the corresponding feature flag to false with the already existing FeatureFlagOverride patch.