### PR TITLE
fix(YouTube Music): Make `Hide 'Get Music Premium' label` and `Remove upgrade button` compatible with latest version

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/fingerprints/HideGetPremiumFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/fingerprints/HideGetPremiumFingerprint.kt
@@ -12,8 +12,6 @@ internal object HideGetPremiumFingerprint : MethodFingerprint(
     listOf(
         Opcode.IF_NEZ,
         Opcode.CONST_16,
-        Opcode.GOTO,
-        Opcode.NOP,
         Opcode.INVOKE_VIRTUAL,
     ),
     listOf("FEmusic_history", "FEmusic_offline"),

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/fingerprints/PivotBarConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/fingerprints/PivotBarConstructorFingerprint.kt
@@ -13,7 +13,6 @@ internal object PivotBarConstructorFingerprint : MethodFingerprint(
         Opcode.CHECK_CAST,
         Opcode.INVOKE_INTERFACE,
         Opcode.GOTO,
-        Opcode.NOP,
         Opcode.IPUT_OBJECT,
         Opcode.RETURN_VOID,
     ),


### PR DESCRIPTION
Weirdly enough, this was the fingerprint used before the latest PR fix. So we are in fact returning to an old fingerprint...