### PR TITLE
fix(YouTube Music): set compatible version for patches

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/HideGetPremiumPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/HideGetPremiumPatch.kt
@@ -16,7 +16,13 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 @Patch(
     name = "Hide 'Get Music Premium' label",
     description = "Hides the \"Get Music Premium\" label from the account menu and settings.",
-    compatiblePackages = [CompatiblePackage("com.google.android.apps.youtube.music")],
+    compatiblePackages = [
+        CompatiblePackage(
+            "com.google.android.apps.youtube.music", [
+                "6.47.53"
+            ]
+        )
+    ]
 )
 @Suppress("unused")
 object HideGetPremiumPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/RemoveUpgradeButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/RemoveUpgradeButtonPatch.kt
@@ -22,7 +22,7 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 @Patch(
     name = "Remove upgrade button",
     description = "Removes the upgrade tab from the pivot bar.",
-        compatiblePackages = [
+    compatiblePackages = [
         CompatiblePackage(
             "com.google.android.apps.youtube.music", [
                 "6.47.53"

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/RemoveUpgradeButtonPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/RemoveUpgradeButtonPatch.kt
@@ -22,7 +22,13 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 @Patch(
     name = "Remove upgrade button",
     description = "Removes the upgrade tab from the pivot bar.",
-    compatiblePackages = [CompatiblePackage("com.google.android.apps.youtube.music")],
+        compatiblePackages = [
+        CompatiblePackage(
+            "com.google.android.apps.youtube.music", [
+                "6.47.53"
+            ]
+        )
+    ]
 )
 @Suppress("unused")
 object RemoveUpgradeButtonPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/gms/GmsCoreSupportPatch.kt
@@ -23,7 +23,13 @@ object GmsCoreSupportPatch : BaseGmsCoreSupportPatch(
     mainActivityOnCreateFingerprint = MusicActivityOnCreateFingerprint,
     integrationsPatchDependency = IntegrationsPatch::class,
     gmsCoreSupportResourcePatch = GmsCoreSupportResourcePatch,
-    compatiblePackages = setOf(CompatiblePackage("com.google.android.apps.youtube.music")),
+    compatiblePackages = [
+        CompatiblePackage(
+            "com.google.android.apps.youtube.music", [
+                "6.47.53"
+            ]
+        )
+    ],
     fingerprints = setOf(
         ServiceCheckFingerprint,
         GooglePlayUtilityFingerprint,


### PR DESCRIPTION
Some patches supports only version `6.47.53` of YT music, so `compatiblePackages` should be set