### PR TITLE
feat(thetransitapp): Add `Unlock transit+` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/thetransitapp/misc/TransitUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/thetransitapp/misc/TransitUnlockPatch.kt
@@ -1,0 +1,23 @@
+package app.revanced.patches.thetransitapp.misc
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.thetransitapp.misc.fingerprints.IsPremiumFingerprint
+
+@Patch(
+    name = "Pro Features Unlock",
+    description = "Unlock all pro features in Transit",
+    compatiblePackages = [
+        CompatiblePackage("com.thetransitapp.droid", ["5.15.16"]),
+    ],
+)
+@Suppress("unused")
+object TransitUnlockPatch :  BytecodePatch(setOf(IsPremiumFingerprint)) {
+    override fun execute(context: BytecodeContext) = IsPremiumFingerprint.result?.let { result ->
+        // put v2 var with true
+        result.mutableMethod.replaceInstruction(6, "const/4 v2, 0x1")
+    } ?: throw IllegalStateException("Fingerprint not found")
+}

--- a/src/main/kotlin/app/revanced/patches/thetransitapp/misc/fingerprints/IsPremiumFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/thetransitapp/misc/fingerprints/IsPremiumFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.thetransitapp.misc.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object IsPremiumFingerprint : MethodFingerprint(
+    // this methode is used to find the fingerprint of the method fetchSubscriptionStatus
+    returnType = "V",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.STATIC,
+    strings = listOf("ForceHasActiveRoyaleSubscription", "product1234"),
+
+)


### PR DESCRIPTION
Unlock all pro features in Transit (com.thetransitapp.droid)