### PR TITLE
fix(YouTube - SponsorBlock): Skip segments when casting

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -29,7 +29,6 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 import com.android.tools.smali.dexlib2.util.MethodUtil
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35c
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Patch(
@@ -39,7 +38,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 object VideoInformationPatch : BytecodePatch(
     setOf(
         PlayerInitFingerprint,
-        MdxPlayerDirectorFingerprint,
+        MdxPlayerDirectorSetVideoStageFingerprint,
         CreateVideoPlayerSeekbarFingerprint,
         PlayerControllerSetTimeReferenceFingerprint,
         OnPlaybackSpeedItemClickFingerprint
@@ -85,7 +84,7 @@ object VideoInformationPatch : BytecodePatch(
             mutableClass.methods.add(seekHelperMethod)
         }
 
-        with(MdxPlayerDirectorFingerprint.resultOrThrow()) {
+        with(MdxPlayerDirectorSetVideoStageFingerprint.resultOrThrow()) {
             mdxInitMethod = mutableClass.methods.first { MethodUtil.isConstructor(it) }
 
             // find the location of the first invoke-direct call and extract the register storing the 'this' object reference
@@ -118,7 +117,7 @@ object VideoInformationPatch : BytecodePatch(
 
                 addInstruction(
                     videoLengthMethodResult.scanResult.patternScanResult!!.endIndex,
-                    "invoke-static {v$videoLengthRegister, v$dummyRegisterForLong}, $INTEGRATIONS_CLASS_DESCRIPTOR->setVideoLength(J)V"
+                    "invoke-static { v$videoLengthRegister, v$dummyRegisterForLong }, $INTEGRATIONS_CLASS_DESCRIPTOR->setVideoLength(J)V"
                 )
             }
         }
@@ -194,7 +193,7 @@ object VideoInformationPatch : BytecodePatch(
             0,
             """
                 sget-object v0, $seekSourceEnumType->a:$seekSourceEnumType
-                invoke-virtual {p0, p1, p2, v0}, $seekMethod
+                invoke-virtual { p0, p1, p2, v0 }, $seekMethod
                 move-result p1
                 return p1
             """

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -95,7 +95,7 @@ object VideoInformationPatch : BytecodePatch(
             onCreateHookMdx(INTEGRATIONS_CLASS_DESCRIPTOR, "initializeMdx")
 
             // MDX seek method
-            val mdxSeekFingerprintResultMethod = MdxSeekFingerprint.also { it.resolve(context, classDef) }.result!!.method
+            val mdxSeekFingerprintResultMethod = MdxSeekFingerprint.apply { resolve(context, classDef) }.resultOrThrow().method
 
             // create helper method
             val mdxSeekHelperMethod = generateSeekMethodHelper(mdxSeekFingerprintResultMethod)

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -176,7 +176,7 @@ object VideoInformationPatch : BytecodePatch(
     private fun generateSeekMethodHelper(seekMethod: Method): MutableMethod {
 
         // create helper method
-        val mdxSeekHelperMethod = ImmutableMethod(
+        val generatedMethod = ImmutableMethod(
             seekMethod.definingClass,
             "seekTo",
             listOf(ImmutableMethodParameter("J", null, "time")),
@@ -190,7 +190,7 @@ object VideoInformationPatch : BytecodePatch(
         val seekSourceEnumType = seekMethod.parameterTypes[1].toString()
 
         // insert helper method instructions
-        mdxSeekHelperMethod.addInstructions(
+        generatedMethod.addInstructions(
             0,
             """
                 sget-object v0, $seekSourceEnumType->a:$seekSourceEnumType
@@ -199,7 +199,7 @@ object VideoInformationPatch : BytecodePatch(
                 return p1
             """
         )
-        return mdxSeekHelperMethod
+        return generatedMethod
     }
 
     private fun MutableMethod.insert(insertIndex: Int, register: String, descriptor: String) =

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -14,6 +14,8 @@ import app.revanced.patches.youtube.video.information.fingerprints.*
 import app.revanced.patches.youtube.video.playerresponse.PlayerResponseMethodHookPatch
 import app.revanced.patches.youtube.video.videoid.VideoIdPatch
 import app.revanced.util.exception
+import app.revanced.util.getReference
+import app.revanced.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.BuilderInstruction
@@ -47,8 +49,8 @@ object VideoInformationPatch : BytecodePatch(
     private var playerInitInsertIndex = 4
 
     private lateinit var mdxInitMethod: MutableMethod
-    private var mdxInitInsertIndex = 5
-    private var mdxInitInsertRegister = 8
+    private var mdxInitInsertIndex = -1
+    private var mdxInitInsertRegister = -1
 
     private lateinit var timeMethod: MutableMethod
     private var timeInitInsertIndex = 2
@@ -84,8 +86,8 @@ object VideoInformationPatch : BytecodePatch(
             mdxInitMethod = mutableClass.methods.first { MethodUtil.isConstructor(it) }
 
             // find the location of the first invoke-direct call and extract the register storing the 'this' object reference
-            mdxInitInsertIndex = mdxInitMethod.implementation!!.instructions.indexOfFirst {
-                it.opcode == Opcode.INVOKE_DIRECT && ((it as Instruction35c).reference as MethodReference).name == "<init>"
+            mdxInitInsertIndex = mdxInitMethod.indexOfFirstInstructionOrThrow {
+                opcode == Opcode.INVOKE_DIRECT && getReference<MethodReference>()?.name == "<init>"
             } + 1
             mdxInitInsertRegister = mdxInitMethod.getInstruction<Instruction35c>(mdxInitInsertIndex - 1).registerC
 

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -87,7 +87,7 @@ object VideoInformationPatch : BytecodePatch(
         with(MdxPlayerDirectorSetVideoStageFingerprint.resultOrThrow()) {
             mdxInitMethod = mutableClass.methods.first { MethodUtil.isConstructor(it) }
 
-            // find the location of the first invoke-direct call and extract the register storing the 'this' object reference.
+            // find the location of the first invoke-direct call and extract the register storing the 'this' object reference
             val initThisIndex = mdxInitMethod.indexOfFirstInstructionOrThrow {
                 opcode == Opcode.INVOKE_DIRECT && getReference<MethodReference>()?.name == "<init>"
             }

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/VideoInformationPatch.kt
@@ -190,7 +190,7 @@ object VideoInformationPatch : BytecodePatch(
             0,
             """
                 sget-object v0, $seekSourceEnumType->a:$seekSourceEnumType
-                invoke-virtual {p0, p1, p2, v0}, ${seekMethod.definingClass}->${seekMethod.name}(J$seekSourceEnumType)Z
+                invoke-virtual {p0, p1, p2, v0}, $seekMethod
                 move-result p1
                 return p1
             """

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxPlayerDirectorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxPlayerDirectorFingerprint.kt
@@ -1,0 +1,8 @@
+package app.revanced.patches.youtube.video.information.fingerprints
+
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+internal object MdxPlayerDirectorFingerprint : MethodFingerprint(
+    strings = listOf("MdxDirector setVideoStage ad should be null when videoStage is not an Ad state ")
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxPlayerDirectorSetVideoStageFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxPlayerDirectorSetVideoStageFingerprint.kt
@@ -3,6 +3,6 @@ package app.revanced.patches.youtube.video.information.fingerprints
 
 import app.revanced.patcher.fingerprint.MethodFingerprint
 
-internal object MdxPlayerDirectorFingerprint : MethodFingerprint(
+internal object MdxPlayerDirectorSetVideoStageFingerprint : MethodFingerprint(
     strings = listOf("MdxDirector setVideoStage ad should be null when videoStage is not an Ad state ")
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.youtube.video.information.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object MdxSeekFingerprint : MethodFingerprint(
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    returnType = "Z",
+    parameters = listOf("J", "L"),
+    customFingerprint = { methodDef, _ ->
+        methodDef.implementation!!.instructions.count() == 3
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
@@ -3,16 +3,21 @@ package app.revanced.patches.youtube.video.information.fingerprints
 import app.revanced.patcher.extensions.or
 import app.revanced.patcher.fingerprint.MethodFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
 internal object MdxSeekFingerprint : MethodFingerprint(
     accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
     returnType = "Z",
     parameters = listOf("J", "L"),
+    opcodes = listOf(
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+        Opcode.RETURN,
+    ),
     customFingerprint = { methodDef, _ ->
         // The instruction count is necessary here to avoid matching the relative version
         // of the seek method we're after, which has the same function signature as the
-        // regular one, is in the same class, and even has the exact same 3 opcodes
-        // at the end (invoke-virtual, move-result, return).
+        // regular one, is in the same class, and even has the exact same 3 opcodes pattern
         methodDef.implementation!!.instructions.count() == 3
     }
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
@@ -9,6 +9,10 @@ internal object MdxSeekFingerprint : MethodFingerprint(
     returnType = "Z",
     parameters = listOf("J", "L"),
     customFingerprint = { methodDef, _ ->
+        // The instruction count is necessary here to avoid matching the relative version
+        // of the seek method we're after, which has the same function signature as the
+        // regular one, is in the same class, and even has the exact same 3 opcodes
+        // at the end (invoke-virtual, move-result, return).
         methodDef.implementation!!.instructions.count() == 3
     }
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/video/information/fingerprints/MdxSeekFingerprint.kt
@@ -17,7 +17,7 @@ internal object MdxSeekFingerprint : MethodFingerprint(
     customFingerprint = { methodDef, _ ->
         // The instruction count is necessary here to avoid matching the relative version
         // of the seek method we're after, which has the same function signature as the
-        // regular one, is in the same class, and even has the exact same 3 opcodes pattern
+        // regular one, is in the same class, and even has the exact same 3 opcodes pattern.
         methodDef.implementation!!.instructions.count() == 3
     }
 )


### PR DESCRIPTION
Add patch code to support skipping segments while casted to a big screen device, by hooking the MDX director class to intercept object instances in order to be able to call the seekTo method, similar to how it's done in the 'regular' player class.

Fixes https://github.com/ReVanced/revanced-patches/issues/374.

Integrations PR: https://github.com/ReVanced/revanced-integrations/pull/655