### PR TITLE
feat(Soundcloud): Add hide ads and disable telemetry patch

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -1010,6 +1010,26 @@ public final class app/revanced/patches/songpal/badge/RemoveNotificationBadgePat
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/soundcloud/ad/AdsPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/soundcloud/ad/AdsPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
+public final class app/revanced/patches/soundcloud/ad/fingerprints/InterceptorFingerprint : app/revanced/patcher/fingerprint/MethodFingerprint {
+	public static final field INSTANCE Lapp/revanced/patches/soundcloud/ad/fingerprints/InterceptorFingerprint;
+}
+
+public final class app/revanced/patches/soundcloud/analytics/AnalyticsPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/soundcloud/analytics/AnalyticsPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
+public final class app/revanced/patches/soundcloud/analytics/fingerprints/TrackingFingerprint : app/revanced/patcher/fingerprint/MethodFingerprint {
+	public static final field INSTANCE Lapp/revanced/patches/soundcloud/analytics/fingerprints/TrackingFingerprint;
+}
+
 public final class app/revanced/patches/spotify/layout/theme/CustomThemePatch : app/revanced/patcher/patch/ResourcePatch {
 	public static final field INSTANCE Lapp/revanced/patches/spotify/layout/theme/CustomThemePatch;
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/AdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/AdsPatch.kt
@@ -1,0 +1,63 @@
+package app.revanced.patches.soundcloud.ad
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patcher.util.smali.ExternalLabel
+import app.revanced.patches.soundcloud.ad.fingerprints.FeaturesFingerprint
+import app.revanced.patches.soundcloud.ad.fingerprints.InterceptorFingerprint
+import app.revanced.patches.soundcloud.ad.fingerprints.PlanFingerprint
+import app.revanced.util.resultOrThrow
+
+@Patch(
+    name = "Remove ads",
+    compatiblePackages = [CompatiblePackage("com.soundcloud.android")]
+)
+@Suppress("unused")
+object AdsPatch : BytecodePatch(
+    setOf(FeaturesFingerprint, PlanFingerprint, InterceptorFingerprint)
+) {
+    override fun execute(context: BytecodeContext) {
+        // Enables a preset feature to disable audio ads by modifying the JSON server response
+        FeaturesFingerprint.resultOrThrow().mutableMethod.apply{
+            addInstructionsWithLabels(
+                2,
+                """
+                    const-string v0, "no_audio_ads"
+                    invoke-virtual {p1, v0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+                    move-result v0
+                    if-eqz v0, :skip
+                    const/4 p2, 0x1
+                """,
+                ExternalLabel("skip", getInstruction(2))
+            )
+        }
+
+        // Overwrites the JSON response from the server to a paid plan which hides all ads in the app
+        // This does not enable paid features as they are all checked for on the backend
+        PlanFingerprint.resultOrThrow().mutableMethod.addInstructions(
+            0,
+            """
+                const-string p1, "high_tier"
+                new-instance p4, Ljava/util/ArrayList;
+                invoke-direct {p4}, Ljava/util/ArrayList;-><init>()V
+                const-string p5, "go-plus"
+                const-string p6, "SoundCloud Go+"
+            """
+        )
+
+        // Prevents the verification of an HTTP header containing the user's current plan which would contradict the previous patch
+        InterceptorFingerprint.resultOrThrow().let { result ->
+            result.mutableMethod.addInstructions(
+                    result.scanResult.patternScanResult!!.endIndex,
+                    """
+                       return-object p1
+                    """
+                )
+        }
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/FeaturesFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/FeaturesFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.soundcloud.ad.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object FeaturesFingerprint : MethodFingerprint(
+    returnType = "V",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf("Ljava/lang/String;", "Z", "Ljava/util/List;"),
+    customFingerprint = { _, classDef ->
+        classDef.sourceFile == "Feature.kt"
+    },
+)

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptorFingerprint.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.soundcloud.ad.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+object InterceptorFingerprint : MethodFingerprint(
+    returnType = "L",
+    accessFlags = AccessFlags.PUBLIC.value,
+    parameters = listOf("L"),
+    opcodes = listOf(
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+        Opcode.IF_EQZ
+    ),
+    strings = listOf("SC-Mob-UserPlan", "Configuration"),
+    customFingerprint = { _, classDef ->
+        classDef.sourceFile == "ApiUserPlanInterceptor.java"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/PlanFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/PlanFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.soundcloud.ad.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object PlanFingerprint : MethodFingerprint(
+    returnType = "V",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf("Ljava/lang/String;", "Z", "Ljava/lang/String;", "Ljava/util/List;", "Ljava/lang/String;", "Ljava/lang/String;"),
+    customFingerprint = { _, classDef ->
+        classDef.sourceFile == "UserConsumerPlan.kt"
+    },
+)

--- a/src/main/kotlin/app/revanced/patches/soundcloud/analytics/AnalyticsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/analytics/AnalyticsPatch.kt
@@ -1,0 +1,30 @@
+package app.revanced.patches.soundcloud.analytics
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.soundcloud.analytics.fingerprints.TrackingFingerprint
+import app.revanced.util.resultOrThrow
+
+@Patch(
+    name = "Disable telemetry",
+    description = "Disables SoundCloud's telemetry system.",
+    compatiblePackages = [CompatiblePackage("com.soundcloud.android")]
+)
+@Suppress("unused")
+object AnalyticsPatch : BytecodePatch(
+    setOf(TrackingFingerprint)
+) {
+    override fun execute(context: BytecodeContext) {
+        // Empties the "backend" argument to abort the initializer
+        TrackingFingerprint.resultOrThrow().mutableMethod.addInstructions(
+            0,
+            """
+                const-string p1, ""
+            """
+        )
+
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/soundcloud/analytics/fingerprints/TrackingFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/analytics/fingerprints/TrackingFingerprint.kt
@@ -1,0 +1,12 @@
+package app.revanced.patches.soundcloud.analytics.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+object TrackingFingerprint : MethodFingerprint(
+    returnType = "L",
+    accessFlags = AccessFlags.PUBLIC.value,
+    customFingerprint = { methodDef, classDef ->
+        classDef.sourceFile == "DefaultTrackingApiFactory.kt" && methodDef.name == "create"
+    }
+)


### PR DESCRIPTION
Removes all ads and disables Soundcloud's in-house telemetry system.
This patch does not give access to any premium features.