### PR TITLE
fix(Windy - Unlock pro): Revert changing package name

### DIFF
--- a/src/main/kotlin/app/revanced/patches/windyapp/misc/unlockpro/UnlockProPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/windyapp/misc/unlockpro/UnlockProPatch.kt
@@ -10,7 +10,7 @@ import app.revanced.patches.windyapp.misc.unlockpro.fingerprints.CheckProFingerp
 @Patch(
     name = "Unlock pro",
     description = "Unlocks all pro features.",
-    compatiblePackages = [CompatiblePackage("com.windyty.android")]
+    compatiblePackages = [CompatiblePackage("co.windyapp.android")]
 )
 @Suppress("unused")
 object UnlockProPatch : BytecodePatch(


### PR DESCRIPTION
Reverts ReVanced/revanced-patches#3397 because the previous package name was correct 