### PR TITLE
feat(Duolingo): Add patches for skipping ads and accessing debug menu

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -193,6 +193,12 @@ public final class app/revanced/patches/cieid/restrictions/root/BypassRootChecks
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/duolingo/ad/RemoveDuolingoAdsPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/duolingo/ad/RemoveDuolingoAdsPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/facebook/ads/story/HideStoryAdsPatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/facebook/ads/story/HideStoryAdsPatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -199,6 +199,12 @@ public final class app/revanced/patches/duolingo/ad/RemoveDuolingoAdsPatch : app
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/duolingo/debug/MakeDebugMenuAvailable : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/duolingo/debug/MakeDebugMenuAvailable;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/facebook/ads/story/HideStoryAdsPatch : app/revanced/patcher/patch/BytecodePatch {
 	public static final field INSTANCE Lapp/revanced/patches/facebook/ads/story/HideStoryAdsPatch;
 	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V

--- a/src/main/kotlin/app/revanced/patches/duolingo/ad/RemoveDuolingoAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/duolingo/ad/RemoveDuolingoAdsPatch.kt
@@ -1,0 +1,42 @@
+package app.revanced.patches.duolingo.ad
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.getInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.duolingo.ad.fingerprints.MonetizationDebugSettingsFingerprint
+import app.revanced.util.exception
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22c
+
+@Patch(
+    name = "Remove Duolingo Ads", compatiblePackages = [CompatiblePackage("com.duolingo")]
+)
+@Suppress("unused")
+object RemoveDuolingoAdsPatch : BytecodePatch(
+    setOf(
+        MonetizationDebugSettingsFingerprint,
+    )
+) {
+    override fun execute(context: BytecodeContext) {
+        // we have a couple of options to approach this:
+        // - `MonetizationDebugSettings` has a boolean value for `disableAds`
+        // - `OnboardingState` has a getter to check if the user has any `adFreeSessions`
+        // - `SharedPreferences` has a debug boolean value with key `disable_ads`, which maps to `DebugCategory.DISABLE_ADS`
+        //
+        // we'll target `MonetizationDebugSettings`, as it seems to be the most general setting that seems to work a-okay
+        MonetizationDebugSettingsFingerprint.result?.mutableMethod?.apply {
+            val firstAssigner = getInstructions().filterIsInstance<BuilderInstruction22c>()
+                .firstOrNull { it.opcode == Opcode.IPUT_BOOLEAN } ?: throw MonetizationDebugSettingsFingerprint.exception
+
+            // force the value of the first assignment (`disableAds`) to be `true`
+            addInstructions(
+                firstAssigner.location.index, """
+                    const/4 v${firstAssigner.registerA}, 0x1
+                """.trimIndent()
+            )
+        } ?: throw MonetizationDebugSettingsFingerprint.exception
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/duolingo/ad/fingerprints/MonetizationDebugSettingsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/duolingo/ad/fingerprints/MonetizationDebugSettingsFingerprint.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.duolingo.ad.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object MonetizationDebugSettingsFingerprint : MethodFingerprint(
+    returnType = "V",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf(
+        "Z", // disableAds
+        "Z", // useDebugBilling
+        "Z", // showManageSubscriptions
+        "Z", // alwaysShowSuperAds
+        "Lcom/duolingo/debug/FamilyQuestOverride;",
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/duolingo/debug/MakeDebugMenuAvailable.kt
+++ b/src/main/kotlin/app/revanced/patches/duolingo/debug/MakeDebugMenuAvailable.kt
@@ -1,0 +1,36 @@
+package app.revanced.patches.duolingo.debug
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.getInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.duolingo.debug.fingerprints.BuildConfigProviderFingerprint
+import app.revanced.util.exception
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22c
+
+@Patch(
+    name = "Make Duolingo debug menu available", compatiblePackages = [CompatiblePackage("com.duolingo")], use = false
+)
+@Suppress("unused")
+object MakeDebugMenuAvailable : BytecodePatch(
+    setOf(
+        BuildConfigProviderFingerprint,
+    )
+) {
+    override fun execute(context: BytecodeContext) {
+        BuildConfigProviderFingerprint.result?.mutableMethod?.apply {
+            val firstAssigner = getInstructions().filterIsInstance<BuilderInstruction22c>()
+                .firstOrNull { it.opcode == Opcode.IPUT_BOOLEAN } ?: throw BuildConfigProviderFingerprint.exception
+
+            // force the value of the first assignment (`isDebugBuild`) to be `true`
+            addInstructions(
+                firstAssigner.location.index, """
+                    const/4 v${firstAssigner.registerA}, 0x1
+                """.trimIndent()
+            )
+        } ?: throw BuildConfigProviderFingerprint.exception
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/duolingo/debug/fingerprints/BuildConfigProviderFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/duolingo/debug/fingerprints/BuildConfigProviderFingerprint.kt
@@ -1,0 +1,18 @@
+package app.revanced.patches.duolingo.debug.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+// the `BuildConfigProvider` class has two bools:
+// - `isChina`: (usually) compares "play" with "china"...except for builds in China
+// - `isDebug`: compares "release" with "debug" <-- we want to force this to `true`
+internal object BuildConfigProviderFingerprint : MethodFingerprint(
+    returnType = "V",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    strings = listOf(
+        "debug",
+        "release",
+        "china",
+    ),
+)


### PR DESCRIPTION
Following up from #3420, I found a reasonably reliable way to skip ads within the app without impacting any of the other features/limitations of free users based on some debug flags within the app.

While I was there, I noticed a way to unlock the debug menu in production builds. I've included that in this PR, but set the `used = false` so it's not available by default, as I don't think generally people should be touching those settings. But it might be useful for some folks looking to target certain language lessons, so I think it's worth keeping it as an option.