### PR TITLE
fix(Instagram - Hide ads):  Restore compatibility with latest version by fixing fingerprint

### DIFF
--- a/src/main/kotlin/app/revanced/patches/instagram/patches/ad/fingerprints/AdInjectorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/instagram/patches/ad/fingerprints/AdInjectorFingerprint.kt
@@ -2,16 +2,13 @@ package app.revanced.patches.instagram.patches.ad.fingerprints
 
 import app.revanced.patcher.fingerprint.MethodFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 internal object AdInjectorFingerprint : MethodFingerprint(
     returnType = "Z",
     accessFlags = AccessFlags.PRIVATE.value,
     parameters = listOf("L", "L"),
-    opcodes = listOf(
-        Opcode.IGET,
-        Opcode.INVOKE_INTERFACE,
-        Opcode.MOVE_RESULT_OBJECT,
+    strings = listOf(
+        "SponsoredContentController.insertItem",
+        "SponsoredContentController::Delivery",
     ),
-    strings = listOf("SponsoredContentController::Delivery"),
 )


### PR DESCRIPTION
Updated the fingerprint of the `Hide ads` patch for the `340.0.0.22.109` version
Should i lock this patch to a specific app version?