### PR TITLE
refactor(YouTube Music): Rename `Hide music video ads` to `Hide multimedia ads` and add patch description

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/ad/video/HideMultimediaAds.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/HideMultimediaAds.kt
@@ -41,7 +41,7 @@ object HideMultimediaAds : BytecodePatch(
 }
 
 @Deprecated("This patch class has been renamed to HideMultimediaAds.")
-object MusicVideoAdsPatch : BytecodePatch(
+object MultimediaAdsPatch : BytecodePatch(
     dependencies = setOf(HideMultimediaAds::class),
 ) {
     override fun execute(context: BytecodeContext) {

--- a/src/main/kotlin/app/revanced/patches/music/ad/video/HideMultimediaAds.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/HideMultimediaAds.kt
@@ -1,0 +1,49 @@
+package app.revanced.patches.music.ad.video
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
+import app.revanced.patches.music.ad.video.fingerprints.ShowMultimediaAdsParentFingerprint
+import app.revanced.util.exception
+
+@Patch(
+    name = "Hide multimedia ads",
+    description = "Hides ads played when listening to or watching music videos, podcasts and songs.",
+    compatiblePackages = [
+        CompatiblePackage(
+            "com.google.android.apps.youtube.music",
+            [
+                "6.45.54",
+                "6.51.53",
+                "7.01.53",
+                "7.02.52",
+                "7.03.52",
+            ]
+        )
+    ],
+)
+@Suppress("unused")
+object HideMultimediaAds : BytecodePatch(
+    setOf(ShowMultimediaAdsParentFingerprint),
+) {
+    override fun execute(context: BytecodeContext) {
+        ShowMultimediaAdsParentFingerprint.result?.let {
+            val showMultimediaAdsMethod = context
+                .toMethodWalker(it.mutableMethod)
+                .nextMethod(it.scanResult.patternScanResult!!.startIndex + 1, true).getMethod() as MutableMethod
+
+            showMultimediaAdsMethod.addInstruction(0, "const/4 p1, 0x0")
+        } ?: throw ShowMultimediaAdsParentFingerprint.exception
+    }
+}
+
+@Deprecated("This patch class has been renamed to HideMultimediaAds.")
+object MusicVideoAdsPatch : BytecodePatch(
+    dependencies = setOf(HideMultimediaAds::class),
+) {
+    override fun execute(context: BytecodeContext) {
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/music/ad/video/fingerprints/ShowMultimediaAdsParentFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/fingerprints/ShowMultimediaAdsParentFingerprint.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.music.ad.video.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object ShowMultimediaAdsParentFingerprint : MethodFingerprint(
+    opcodes = listOf(
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.IGET_OBJECT,
+    ),
+    strings = listOf("maybeRegenerateCpnAndStatsClient called unexpectedly, but no error."),
+)


### PR DESCRIPTION
Closes #3378 