### PR TITLE
fix(SwissID): Rename `Remove Google Play Integrity Integrity check` to `Remove Google Play Integrity check`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/swissid/integritycheck/RemoveGooglePlayIntegrityCheck.kt
+++ b/src/main/kotlin/app/revanced/patches/swissid/integritycheck/RemoveGooglePlayIntegrityCheck.kt
@@ -9,7 +9,7 @@ import app.revanced.patches.swissid.integritycheck.fingerprints.CheckIntegrityFi
 import app.revanced.util.resultOrThrow
 
 @Patch(
-    name = "Remove Google Play Integrity Integrity check",
+    name = "Remove Google Play Integrity check",
     description = "Removes the Google Play Integrity check. With this it's possible to use SwissID on custom ROMS." +
             "If the device is rooted, root permissions must be hidden from the app.",
     compatiblePackages = [CompatiblePackage("com.swisssign.swissid.mobile")],


### PR DESCRIPTION
Found this when surfing the ReVanced Website for issue to bother them (in a friendly way, of course. totally)