### PR TITLE
fix(pixiv): `Hide Ads` fingerprint unable to resolve

### DIFF
--- a/src/main/kotlin/app/revanced/patches/pixiv/ads/HideAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/pixiv/ads/HideAdsPatch.kt
@@ -7,22 +7,28 @@ import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.annotation.CompatiblePackage
 import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.patches.pixiv.ads.fingerprints.IsNotPremiumFingerprint
+import app.revanced.patches.pixiv.ads.fingerprints.ShouldShowAdsFingerprint
 
 @Patch(
     name = "Hide ads",
     compatiblePackages = [CompatiblePackage("jp.pxv.android")]
 )
 @Suppress("unused")
-object HideAdsPatch : BytecodePatch(setOf(IsNotPremiumFingerprint)) {
-    // Always return false in the "isNotPremium" method which normally returns !this.accountManager.isPremium.
+object HideAdsPatch : BytecodePatch(setOf(IsNotPremiumFingerprint, ShouldShowAdsFingerprint)) {
+    // Always return false in the "isNotPremium" or "shouldShowAds" method which normally returns !this.accountManager.isPremium.
     // However, this is not the method that controls the user's premium status.
     // Instead, this method is used to determine whether ads should be shown.
-    override fun execute(context: BytecodeContext) =
-        IsNotPremiumFingerprint.result?.mutableClass?.virtualMethods?.first()?.addInstructions(
+    override fun execute(context: BytecodeContext) {
+        val method = IsNotPremiumFingerprint.result?.mutableClass?.virtualMethods?.first() // Fingerprint for older version
+            ?: ShouldShowAdsFingerprint.result?.mutableMethod // Fingerprint for newer version
+            ?: throw ShouldShowAdsFingerprint.exception
+
+        method.addInstructions(
             0,
             """
                 const/4 v0, 0x0
                 return v0
             """
-        ) ?: throw IsNotPremiumFingerprint.exception
+        )
+    }
 }

--- a/src/main/kotlin/app/revanced/patches/pixiv/ads/fingerprints/ShouldShowAdsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/pixiv/ads/fingerprints/ShouldShowAdsFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.pixiv.ads.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+
+internal object ShouldShowAdsFingerprint : MethodFingerprint(
+    "Z",
+    AccessFlags.PUBLIC or AccessFlags.FINAL,
+    customFingerprint = { methodDef, classDef ->
+        classDef.type.endsWith("AdUtils;") && methodDef.name == "shouldShowAds"
+    }
+)


### PR DESCRIPTION
Fixes #3591 

Ads a second fingerprint for newer recent version where the method names aren't obfuscated.

Tested with version 6.121.1 (latest).

Reasoning: A second fingerprint is added to still allow patching of older versions whilst also allowing the patching of newer versions hence maintaining compatibility and if methods are to be obfuscated again then the fingerprints will still work.