### PR TITLE
fix(Soundcloud - Hide ads): Support latest version

### DIFF
--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/HideAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/HideAdsPatch.kt
@@ -62,7 +62,7 @@ object HideAdsPatch : BytecodePatch(
 
         // Prevent verification of an HTTP header containing the user's current plan, which would contradict the previous patch.
         InterceptFingerprint.resultOrThrow().let { result ->
-            val conditionIndex = result.scanResult.patternScanResult!!.endIndex
+            val conditionIndex = result.scanResult.patternScanResult!!.endIndex + 1
             result.mutableMethod.addInstruction(
                 conditionIndex,
                 "return-object p1",

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptFingerprint.kt
@@ -9,12 +9,13 @@ internal object InterceptFingerprint : MethodFingerprint(
     accessFlags = AccessFlags.PUBLIC.value,
     parameters = listOf("L"),
     opcodes = listOf(
-        Opcode.INVOKE_INTERFACE,
         Opcode.MOVE_RESULT_OBJECT,
-        Opcode.CONST_4
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT_OBJECT
     ),
     strings = listOf("SC-Mob-UserPlan", "Configuration"),
     customFingerprint = { _, classDef ->
+        classDef.sourceFile == "ApiUserPlanInterceptor.java" ||
         classDef.sourceFile == "ApiUserPlanInterceptor.kt"
     },
 )

--- a/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/soundcloud/ad/fingerprints/InterceptFingerprint.kt
@@ -11,12 +11,10 @@ internal object InterceptFingerprint : MethodFingerprint(
     opcodes = listOf(
         Opcode.INVOKE_INTERFACE,
         Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT,
-        Opcode.IF_EQZ,
+        Opcode.CONST_4
     ),
     strings = listOf("SC-Mob-UserPlan", "Configuration"),
     customFingerprint = { _, classDef ->
-        classDef.sourceFile == "ApiUserPlanInterceptor.java"
+        classDef.sourceFile == "ApiUserPlanInterceptor.kt"
     },
 )


### PR DESCRIPTION
- InterceptFingerprint is now resolving in newer versions (#3619)

Minimum version: `2024.09.03-beta`

Unfortunately, this pull request currently only works with the latest beta versions and makes older versions stop working. Is there an option to add an old fingerprint to support older versions? If so, how would I do that?