### PR TITLE
fix(Twitter - Open links with app chooser): Fix incorrect version in compatibility list

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/misc/links/OpenLinksWithAppChooserPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/links/OpenLinksWithAppChooserPatch.kt
@@ -12,7 +12,7 @@ import app.revanced.util.exception
     name = "Open links with app chooser",
     description = "Instead of opening links directly, open them with an app chooser. " +
         "As a result you can select a browser to open the link with.",
-    compatiblePackages = [CompatiblePackage("com.twitter.android", ["10.48.0-release"])],
+    compatiblePackages = [CompatiblePackage("com.twitter.android", ["10.48.0-release.0"])],
     use = false,
 )
 @Suppress("unused")


### PR DESCRIPTION
the patch has a suggested version set, but the version value set here is incorrect, causing users of the ReVanced-manager to receive a warning that they are not using a suggested correct value should be "10.48.0.release.0"
<https://www.apkmirror.com/?post_type=app_release&searchtype=apk&s=twitter+10.48.0-release.&bundles%5B%5D=apkm_bundles&bundles%5B%5D=apk_files>
(if it is inappropriate to change the values ​​in this patch itself and it should be handled somewhere else, pls comment)