### PR TITLE
feat(Backdrops): Remove version constraint

### DIFF
--- a/src/main/kotlin/app/revanced/patches/backdrops/misc/pro/ProUnlockPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/backdrops/misc/pro/ProUnlockPatch.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Patch(
     name = "Pro unlock",
-    compatiblePackages = [CompatiblePackage("com.backdrops.wallpapers", ["4.52"])]
+    compatiblePackages = [CompatiblePackage("com.backdrops.wallpapers")]
 )
 @Suppress("unused")
 object ProUnlockPatch : BytecodePatch(


### PR DESCRIPTION
By using [APKeditor](https://github.com/REAndroid/APKEditor?tab=readme-ov-file#3--merge) or [AntiSplit M](https://github.com/AbdurazaaqMohammed/AntiSplit-M) you can merge the bundle apk & patch all latest versions of Backdrops.