### PR TITLE
fix(sync): Reddit video downloader

### DIFF
--- a/api/revanced-patches.api
+++ b/api/revanced-patches.api
@@ -840,6 +840,12 @@ public final class app/revanced/patches/reddit/customclients/syncforreddit/fix/u
 	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
 }
 
+public final class app/revanced/patches/reddit/customclients/syncforreddit/fix/video/FixRedditVideoDownloadPatch : app/revanced/patcher/patch/BytecodePatch {
+	public static final field INSTANCE Lapp/revanced/patches/reddit/customclients/syncforreddit/fix/video/FixRedditVideoDownloadPatch;
+	public fun execute (Lapp/revanced/patcher/data/BytecodeContext;)V
+	public synthetic fun execute (Lapp/revanced/patcher/data/Context;)V
+}
+
 public final class app/revanced/patches/reddit/customclients/syncforreddit/misc/integrations/IntegrationsPatch : app/revanced/patches/shared/misc/integrations/BaseIntegrationsPatch {
 	public static final field INSTANCE Lapp/revanced/patches/reddit/customclients/syncforreddit/misc/integrations/IntegrationsPatch;
 }

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/syncforreddit/fix/video/FixRedditVideoDownloadPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/syncforreddit/fix/video/FixRedditVideoDownloadPatch.kt
@@ -1,0 +1,52 @@
+package app.revanced.patches.reddit.customclients.syncforreddit.fix.video
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.reddit.customclients.syncforreddit.fix.video.fingerprints.RedditVideoRequestFingerprint
+import app.revanced.util.indexOfFirstInstruction
+import app.revanced.util.resultOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+
+@Patch(
+    name = "Fix Reddit video download",
+    description = "Fixes a bug in Sync's MPD parser resulting in only the audio-track being saved",
+    compatiblePackages = [
+        CompatiblePackage("com.laurencedawson.reddit_sync"),
+        CompatiblePackage("com.laurencedawson.reddit_sync.pro"),
+        CompatiblePackage("com.laurencedawson.reddit_sync.dev"),
+    ],
+    requiresIntegrations = true,
+    use = false,
+)
+@Suppress("unused")
+object FixRedditVideoDownloadPatch : BytecodePatch(
+    fingerprints = setOf(RedditVideoRequestFingerprint),
+) {
+    private const val integrationsClassDescriptor = "Lapp/revanced/integrations/syncforreddit/FixRedditVideoDownloadPatch;"
+    private const val getLinksMethod = "getLinks([B)[Ljava/lang/String;"
+
+    override fun execute(context: BytecodeContext) {
+        val downloadMethod = RedditVideoRequestFingerprint.resultOrThrow().mutableMethod
+        val constIdx = downloadMethod.indexOfFirstInstruction { opcode == Opcode.CONST_WIDE_32 } - 2
+
+        downloadMethod.addInstructions(constIdx, """
+            iget-object v2, p1, Lcom/android/volley/NetworkResponse;->data:[B
+            invoke-static { v2 }, $integrationsClassDescriptor->$getLinksMethod
+            move-result-object v2
+            
+            # videoUrl at idx 0
+            const/4 v5, 0x0
+            aget-object v3, v2, v5
+
+            # audioUrl at idx 1
+            const/4 v6, 0x1
+            aget-object v4, v2, v6
+        """.trimIndent())
+
+        downloadMethod.removeInstructions(0, constIdx)
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/reddit/customclients/syncforreddit/fix/video/fingerprints/RedditVideoRequestFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/reddit/customclients/syncforreddit/fix/video/fingerprints/RedditVideoRequestFingerprint.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.reddit.customclients.syncforreddit.fix.video.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+internal object RedditVideoRequestFingerprint : MethodFingerprint(
+    customFingerprint = { methodDef, classDef ->
+        classDef.sourceFile == "RedditVideoRequest.java" && methodDef.name == "parseNetworkResponse"
+    }
+)


### PR DESCRIPTION
I found a bug in Sync Reddit which resulted in only the audio track being saved when downloading videos from Reddit due to a weird check for the video track - I've gone ahead and added a integrations-patch which re-implements the functionality, bypassing the existing implementation