### PR TITLE
feat(YouTube - Hide Shorts components): Hide `Use template`, `Upcoming`, `Green screen` buttons

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsResourcePatch.kt
@@ -43,6 +43,8 @@ object HideShortsComponentsResourcePatch : ResourcePatch() {
             SwitchPreference("revanced_hide_shorts_paused_overlay_buttons"),
             SwitchPreference("revanced_hide_shorts_save_sound_button"),
             SwitchPreference("revanced_hide_shorts_use_template_button"),
+            SwitchPreference("revanced_hide_shorts_upcoming_button"),
+            SwitchPreference("revanced_hide_shorts_green_screen_button"),
             SwitchPreference("revanced_hide_shorts_shop_button"),
             SwitchPreference("revanced_hide_shorts_tagged_products"),
             SwitchPreference("revanced_hide_shorts_stickers"),

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/shorts/HideShortsComponentsResourcePatch.kt
@@ -42,6 +42,7 @@ object HideShortsComponentsResourcePatch : ResourcePatch() {
             SwitchPreference("revanced_hide_shorts_subscribe_button"),
             SwitchPreference("revanced_hide_shorts_paused_overlay_buttons"),
             SwitchPreference("revanced_hide_shorts_save_sound_button"),
+            SwitchPreference("revanced_hide_shorts_use_template_button"),
             SwitchPreference("revanced_hide_shorts_shop_button"),
             SwitchPreference("revanced_hide_shorts_tagged_products"),
             SwitchPreference("revanced_hide_shorts_stickers"),

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -639,6 +639,9 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_hide_shorts_save_sound_button_title">Hide save music button</string>
             <string name="revanced_hide_shorts_save_sound_button_summary_on">Save music is hidden</string>
             <string name="revanced_hide_shorts_save_sound_button_summary_off">Save music is shown</string>
+            <string name="revanced_hide_shorts_use_template_button_title">Hide use template button</string>
+            <string name="revanced_hide_shorts_use_template_button_summary_on">Use template is hidden</string>
+            <string name="revanced_hide_shorts_use_template_button_summary_off">Use template is shown</string>
             <string name="revanced_hide_shorts_search_suggestions_title">Hide search suggestions</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_on">Search suggestions are hidden</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_off">Search suggestions are shown</string>

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -637,11 +637,11 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_hide_shorts_location_label_summary_on">Location label is hidden</string>
             <string name="revanced_hide_shorts_location_label_summary_off">Location label is shown</string>
             <string name="revanced_hide_shorts_save_sound_button_title">Hide save music button</string>
-            <string name="revanced_hide_shorts_save_sound_button_summary_on">Save music is hidden</string>
-            <string name="revanced_hide_shorts_save_sound_button_summary_off">Save music is shown</string>
+            <string name="revanced_hide_shorts_save_sound_button_summary_on">Save music button is hidden</string>
+            <string name="revanced_hide_shorts_save_sound_button_summary_off">Save music button is shown</string>
             <string name="revanced_hide_shorts_use_template_button_title">Hide use template button</string>
-            <string name="revanced_hide_shorts_use_template_button_summary_on">Use template is hidden</string>
-            <string name="revanced_hide_shorts_use_template_button_summary_off">Use template is shown</string>
+            <string name="revanced_hide_shorts_use_template_button_summary_on">Use template button is hidden</string>
+            <string name="revanced_hide_shorts_use_template_button_summary_off">Use template button is shown</string>
             <string name="revanced_hide_shorts_search_suggestions_title">Hide search suggestions</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_on">Search suggestions are hidden</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_off">Search suggestions are shown</string>

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -642,6 +642,12 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_hide_shorts_use_template_button_title">Hide use template button</string>
             <string name="revanced_hide_shorts_use_template_button_summary_on">Use template button is hidden</string>
             <string name="revanced_hide_shorts_use_template_button_summary_off">Use template button is shown</string>
+            <string name="revanced_hide_shorts_upcoming_button_title">Hide upcoming button</string>
+            <string name="revanced_hide_shorts_upcoming_button_summary_on">Upcoming button is hidden</string>
+            <string name="revanced_hide_shorts_upcoming_button_summary_off">Upcoming button is shown</string>
+            <string name="revanced_hide_shorts_green_screen_button_title">Hide green screen button</string>
+            <string name="revanced_hide_shorts_green_screen_button_summary_on">Green screen button is hidden</string>
+            <string name="revanced_hide_shorts_green_screen_button_summary_off">Green screen button is shown</string>
             <string name="revanced_hide_shorts_search_suggestions_title">Hide search suggestions</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_on">Search suggestions are hidden</string>
             <string name="revanced_hide_shorts_search_suggestions_summary_off">Search suggestions are shown</string>


### PR DESCRIPTION
Closes https://github.com/ReVanced/revanced-patches/issues/3751

[Integration changes](https://github.com/ReVanced/revanced-integrations/pull/714)