### PR TITLE
fix(Twitter - Unlock downloads):  Make it work with latest versions

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/interaction/downloads/fingerprints/BuildMediaOptionsSheetFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/interaction/downloads/fingerprints/BuildMediaOptionsSheetFingerprint.kt
@@ -10,5 +10,5 @@ internal object BuildMediaOptionsSheetFingerprint : MethodFingerprint(
         Opcode.GOTO_16,
         Opcode.NEW_INSTANCE,
     ),
-    strings = listOf("resources.getString(R.string.post_video)"),
+    strings = listOf("mediaEntity", "media_options_sheet"),
 )

--- a/src/main/kotlin/app/revanced/patches/twitter/interaction/downloads/fingerprints/ShowDownloadVideoUpsellBottomSheetFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/interaction/downloads/fingerprints/ShowDownloadVideoUpsellBottomSheetFingerprint.kt
@@ -5,6 +5,6 @@ import com.android.tools.smali.dexlib2.Opcode
 
 internal object ShowDownloadVideoUpsellBottomSheetFingerprint : MethodFingerprint(
     returnType = "Z",
-    strings = listOf("variantToDownload.url"),
+    strings = listOf("mediaEntity", "url"),
     opcodes = listOf(Opcode.IF_EQZ)
 )


### PR DESCRIPTION
Some strings got removed, tested patching and it seems to work on 10.64.0-alpha, may need more testing
Should fix #3777 