### PR TITLE
fix(Twitter - Change link sharing domain): Support latest app version

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/misc/links/ChangeLinkSharingDomainResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/links/ChangeLinkSharingDomainResourcePatch.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.twitter.misc.links
+
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.ResourcePatch
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patches.shared.misc.mapping.ResourceMappingPatch
+
+@Patch(
+    dependencies = [ResourceMappingPatch::class],
+)
+internal object ChangeLinkSharingDomainResourcePatch : ResourcePatch() {
+    internal var tweetShareLinkTemplateId: Long = -1
+
+    override fun execute(context: ResourceContext) {
+        tweetShareLinkTemplateId = ResourceMappingPatch["string", "tweet_share_link"]
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/twitter/misc/links/fingerprints/LinkResourceGetterFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/links/fingerprints/LinkResourceGetterFingerprint.kt
@@ -1,12 +1,13 @@
 package app.revanced.patches.twitter.misc.links.fingerprints
 
 import app.revanced.patcher.extensions.or
-import app.revanced.patcher.fingerprint.MethodFingerprint
+import app.revanced.patches.twitter.misc.links.ChangeLinkSharingDomainResourcePatch
+import app.revanced.util.patch.LiteralValueFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 
 // Gets Resource string for share link view available by pressing "Share via" button.
-internal object LinkResourceGetterFingerprint : MethodFingerprint(
+internal object LinkResourceGetterFingerprint : LiteralValueFingerprint(
     accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
     parameters = listOf("Landroid/content/res/Resources;"),
-    strings = listOf("res.getString(R.string.t…lUsername, id.toString())"),
+    literalSupplier = { ChangeLinkSharingDomainResourcePatch.tweetShareLinkTemplateId }
 )


### PR DESCRIPTION
New alpha version broke the patch, I switched to finding a resource id here so it should be more stable in the future.