### PR TITLE
feat(YouTube - Hide layout components): Hide player shopping shelf

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -91,6 +91,10 @@ object HideLayoutComponentsPatch : BytecodePatch(
     override fun execute(context: BytecodeContext) {
         AddResourcesPatch(this::class)
 
+        SettingsPatch.PreferenceScreen.ADS.addPreferences(
+            SwitchPreference("revanced_hide_player_store_shelf"),
+        )
+
         SettingsPatch.PreferenceScreen.PLAYER.addPreferences(
             PreferenceScreen(
                 key = "revanced_hide_description_components_screen",
@@ -113,7 +117,7 @@ object HideLayoutComponentsPatch : BytecodePatch(
                     SwitchPreference("revanced_hide_comments_thanks_button"),
                     SwitchPreference("revanced_hide_comments_timestamp_and_emoji_buttons")
                 ),
-                sorting = PreferenceScreen.Sorting.UNSORTED
+                sorting = Sorting.UNSORTED
             ),
             SwitchPreference("revanced_hide_channel_bar"),
             SwitchPreference("revanced_hide_channel_guidelines"),

--- a/src/main/resources/addresources/values/strings.xml
+++ b/src/main/resources/addresources/values/strings.xml
@@ -107,6 +107,9 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_disable_like_subscribe_glow_title">Disable like / subscribe button glow</string>
             <string name="revanced_disable_like_subscribe_glow_summary_on">Like and subscribe button will not glow when mentioned</string>
             <string name="revanced_disable_like_subscribe_glow_summary_off">Like and subscribe button will glow when mentioned</string>
+            <string name="revanced_hide_player_store_shelf_title">Hide player shopping shelf</string>
+            <string name="revanced_hide_player_store_shelf_summary_on">Shopping shelf is hidden</string>
+            <string name="revanced_hide_player_store_shelf_summary_off">Shopping shelf is shown</string>
             <string name="revanced_hide_album_cards_title">Hide album cards</string>
             <string name="revanced_hide_album_cards_summary_on">Album cards are hidden</string>
             <string name="revanced_hide_album_cards_summary_off">Album cards are shown</string>


### PR DESCRIPTION
With 19.24 and later, the video player can show under the video a shopping shelf with merchandise from the channel.

Enabling `hide horizontal shelves` will hide this, but this can be selectively hidden since this is the only shelf that can appear in the video player.

This PR adds a new hide ads setting to hide this specific type of shelf (enabled by default).


![shopping shelf](https://github.com/user-attachments/assets/9c149d0b-b810-4e19-b509-f8e4054740bc)



[Integration changes](https://github.com/ReVanced/revanced-integrations/pull/723)
