### PR TITLE
chore(YouTube - Announcements): Use API v4 to get announcements

### DIFF
--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/announcements/requests/AnnouncementsRoutes.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/announcements/requests/AnnouncementsRoutes.java
@@ -9,12 +9,9 @@ import java.net.HttpURLConnection;
 import static app.revanced.extension.youtube.requests.Route.Method.GET;
 
 public class AnnouncementsRoutes {
-    private static final String ANNOUNCEMENTS_PROVIDER = "https://api.revanced.app/v2";
-
-    /**
-     * 'language' parameter is IETF format (for USA it would be 'en-us').
-     */
-    public static final Route GET_LATEST_ANNOUNCEMENT = new Route(GET, "/announcements/youtube/latest?language={language}");
+    public static final Route GET_LATEST_ANNOUNCEMENTS = new Route(GET, "/announcements/latest?tag=youtube");
+    public static final Route GET_LATEST_ANNOUNCEMENT_IDS = new Route(GET, "/announcements/latest/id?tag=youtube");
+    private static final String ANNOUNCEMENTS_PROVIDER = "https://api.revanced.app/v4";
 
     private AnnouncementsRoutes() {
     }


### PR DESCRIPTION
This PR updates the Announcements patch to use API v4. With v4 now, the ID can be requested only. Announcements also now have an archived_at field. If the announcement is archived, even if it's the latest and has not been read, it will not be shown. This is useful for new users when the announcement is no longer relevant.