### PR TITLE
fix(My Expenses - Unlock pro): Constrain compatible version to working version

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/myexpenses/misc/pro/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/myexpenses/misc/pro/UnlockProPatch.kt
@@ -7,7 +7,7 @@ import app.revanced.patcher.patch.bytecodePatch
 val unlockProPatch = bytecodePatch(
     name = "Unlock pro",
 ) {
-    compatibleWith("org.totschnig.myexpenses")
+    compatibleWith("org.totschnig.myexpenses"("3.4.9"))
 
     execute {
         isEnabledFingerprint.method.addInstructions(


### PR DESCRIPTION
Restores a version constrain that was present but got lost in the patcher 5.0 migration

https://github.com/ReVanced/revanced-patches/commit/f68c87b0edc88e80ef2f3110f75be86236dffdb7