### PR TITLE
fix(YouTube - Playback speed): Allow long press 2x speed when using custom playback speeds

### DIFF
--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/VideoInformation.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/VideoInformation.java
@@ -122,6 +122,16 @@ public final class VideoInformation {
 
     /**
      * Injection point.
+     */
+    public static void videoSpeedChanged(float currentVideoSpeed) {
+        if (playbackSpeed != currentVideoSpeed) {
+            Logger.printDebug(() -> "Video speed changed: " + currentVideoSpeed);
+            playbackSpeed = currentVideoSpeed;
+        }
+    }
+
+    /**
+     * Injection point.
      * Called when user selects a playback speed.
      *
      * @param userSelectedPlaybackSpeed The playback speed the user selected
@@ -137,10 +147,10 @@ public final class VideoInformation {
      * <b> Used exclusively by {@link RememberPlaybackSpeedPatch} </b>
      */
     public static void overridePlaybackSpeed(float speedOverride) {
-        if (playbackSpeed != speedOverride) {
-            Logger.printDebug(() -> "Overriding playback speed to: " + speedOverride);
-            playbackSpeed = speedOverride;
-        }
+        if (speedOverride <= 0) throw new IllegalArgumentException("Invalid speed override: " + speedOverride);
+
+        Logger.printDebug(() -> "Overriding playback speed to: " + speedOverride);
+        playbackSpeed = speedOverride;
     }
 
     /**

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/VideoInformation.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/VideoInformation.java
@@ -1,13 +1,13 @@
 package app.revanced.extension.youtube.patches;
 
 import androidx.annotation.NonNull;
-import app.revanced.extension.youtube.patches.playback.speed.RememberPlaybackSpeedPatch;
-import app.revanced.extension.youtube.shared.VideoState;
-import app.revanced.extension.shared.Logger;
-import app.revanced.extension.shared.Utils;
 
 import java.lang.ref.WeakReference;
 import java.util.Objects;
+
+import app.revanced.extension.shared.Logger;
+import app.revanced.extension.shared.Utils;
+import app.revanced.extension.youtube.shared.VideoState;
 
 /**
  * Hooking class for the current playing video.
@@ -139,18 +139,6 @@ public final class VideoInformation {
     public static void userSelectedPlaybackSpeed(float userSelectedPlaybackSpeed) {
         Logger.printDebug(() -> "User selected playback speed: " + userSelectedPlaybackSpeed);
         playbackSpeed = userSelectedPlaybackSpeed;
-    }
-
-    /**
-     * Overrides the current playback speed.
-     * <p>
-     * <b> Used exclusively by {@link RememberPlaybackSpeedPatch} </b>
-     */
-    public static void overridePlaybackSpeed(float speedOverride) {
-        if (speedOverride <= 0) throw new IllegalArgumentException("Invalid speed override: " + speedOverride);
-
-        Logger.printDebug(() -> "Overriding playback speed to: " + speedOverride);
-        playbackSpeed = speedOverride;
     }
 
     /**

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -20,12 +20,8 @@ public final class RememberPlaybackSpeedPatch {
      * Injection point.
      */
     public static void newVideoStarted(VideoInformation.PlaybackController ignoredPlayerController) {
-        try {
-            Logger.printDebug(() -> "newVideoStarted");
-            newVideoStarted = true;
-        } catch (Exception ex) {
-            Logger.printException(() -> "newVideoStarted failure", ex);
-        }
+        Logger.printDebug(() -> "newVideoStarted");
+        newVideoStarted = true;
     }
 
     /**

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -12,14 +12,20 @@ public final class RememberPlaybackSpeedPatch {
 
     private static final long TOAST_DELAY_MILLISECONDS = 750;
 
+    private static volatile boolean newVideoStarted;
+
     private static long lastTimeSpeedChanged;
 
     /**
      * Injection point.
      */
     public static void newVideoStarted(VideoInformation.PlaybackController ignoredPlayerController) {
-        Logger.printDebug(() -> "newVideoStarted");
-        VideoInformation.overridePlaybackSpeed(Settings.PLAYBACK_SPEED_DEFAULT.get());
+        try {
+            Logger.printDebug(() -> "newVideoStarted");
+            newVideoStarted = true;
+        } catch (Exception ex) {
+            Logger.printException(() -> "newVideoStarted failure", ex);
+        }
     }
 
     /**
@@ -29,42 +35,56 @@ public final class RememberPlaybackSpeedPatch {
      * @param playbackSpeed The playback speed the user selected
      */
     public static void userSelectedPlaybackSpeed(float playbackSpeed) {
-        if (Settings.REMEMBER_PLAYBACK_SPEED_LAST_SELECTED.get()) {
-            // With the 0.05x menu, if the speed is set by integrations to higher than 2.0x
-            // then the menu will allow increasing without bounds but the max speed is
-            // still capped to under 8.0x.
-            playbackSpeed = Math.min(playbackSpeed, CustomPlaybackSpeedPatch.PLAYBACK_SPEED_MAXIMUM - 0.05f);
+        try {
+            if (Settings.REMEMBER_PLAYBACK_SPEED_LAST_SELECTED.get()) {
+                // With the 0.05x menu, if the speed is set by integrations to higher than 2.0x
+                // then the menu will allow increasing without bounds but the max speed is
+                // still capped to under 8.0x.
+                playbackSpeed = Math.min(playbackSpeed, CustomPlaybackSpeedPatch.PLAYBACK_SPEED_MAXIMUM - 0.05f);
 
-            // Prevent toast spamming if using the 0.05x adjustments.
-            // Show exactly one toast after the user stops interacting with the speed menu.
-            final long now = System.currentTimeMillis();
-            lastTimeSpeedChanged = now;
+                // Prevent toast spamming if using the 0.05x adjustments.
+                // Show exactly one toast after the user stops interacting with the speed menu.
+                final long now = System.currentTimeMillis();
+                lastTimeSpeedChanged = now;
 
-            final float finalPlaybackSpeed = playbackSpeed;
-            Utils.runOnMainThreadDelayed(() -> {
-                if (lastTimeSpeedChanged != now) {
-                    // The user made additional speed adjustments and this call is outdated.
-                    return;
-                }
+                final float finalPlaybackSpeed = playbackSpeed;
+                Utils.runOnMainThreadDelayed(() -> {
+                    if (lastTimeSpeedChanged != now) {
+                        // The user made additional speed adjustments and this call is outdated.
+                        return;
+                    }
 
-                if (Settings.PLAYBACK_SPEED_DEFAULT.get() == finalPlaybackSpeed) {
-                    // User changed to a different speed and immediately changed back.
-                    // Or the user is going past 8.0x in the glitched out 0.05x menu.
-                    return;
-                }
-                Settings.PLAYBACK_SPEED_DEFAULT.save(finalPlaybackSpeed);
+                    if (Settings.PLAYBACK_SPEED_DEFAULT.get() == finalPlaybackSpeed) {
+                        // User changed to a different speed and immediately changed back.
+                        // Or the user is going past 8.0x in the glitched out 0.05x menu.
+                        return;
+                    }
+                    Settings.PLAYBACK_SPEED_DEFAULT.save(finalPlaybackSpeed);
 
-                Utils.showToastLong(str("revanced_remember_playback_speed_toast", (finalPlaybackSpeed + "x")));
-            }, TOAST_DELAY_MILLISECONDS);
+                    Utils.showToastLong(str("revanced_remember_playback_speed_toast", (finalPlaybackSpeed + "x")));
+                }, TOAST_DELAY_MILLISECONDS);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "userSelectedPlaybackSpeed failure", ex);
         }
     }
 
     /**
      * Injection point.
-     * Overrides the video speed.  Called after video loads, and immediately after user selects a different playback speed
+     * Overrides the video speed.  Called after video loads,
+     * and immediately after the user selects a different playback speed.
      */
     public static float getPlaybackSpeedOverride() {
-        return VideoInformation.getPlaybackSpeed();
+        if (newVideoStarted) {
+            newVideoStarted = false;
+
+            final float defaultSpeed = Settings.PLAYBACK_SPEED_DEFAULT.get();
+            if (defaultSpeed > 0) {
+                return defaultSpeed;
+            }
+        }
+
+        return -2.0f;
     }
 
 }

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -1376,6 +1376,7 @@ public final class app/revanced/patches/youtube/video/information/VideoInformati
 	public static final fun getVideoInformationPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 	public static final fun userSelectedPlaybackSpeedHook (Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun videoTimeHook (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun videoVideoSpeedChanged (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public abstract class app/revanced/patches/youtube/video/playerresponse/Hook {

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -1370,13 +1370,10 @@ public final class app/revanced/patches/youtube/shared/FingerprintsKt {
 }
 
 public final class app/revanced/patches/youtube/video/information/VideoInformationPatchKt {
-	public static final fun getSetPlaybackSpeedClassFieldReference ()Ljava/lang/String;
-	public static final fun getSetPlaybackSpeedContainerClassFieldReference ()Ljava/lang/String;
-	public static final fun getSetPlaybackSpeedMethodReference ()Ljava/lang/String;
 	public static final fun getVideoInformationPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 	public static final fun userSelectedPlaybackSpeedHook (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun videoSpeedChangedHook (Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun videoTimeHook (Ljava/lang/String;Ljava/lang/String;)V
-	public static final fun videoVideoSpeedChanged (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public abstract class app/revanced/patches/youtube/video/playerresponse/Hook {


### PR DESCRIPTION
Fixes tap and hold for 2x speed not working when using a default playback speed.

If using custom playback speeds and the current speed is higher than 2.0x, then the hold for 2x effectively does nothing.  It's caused by the logic in YouTube assuming the playback speed cannot be above it's unpatched max of 2.0x

