### PR TITLE
fix(YouTube - Spoof video streams): Log out the iOS client to allow kids videos playback

### DIFF
--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
@@ -9,7 +9,7 @@ import androidx.annotation.Nullable;
 
 public enum ClientType {
     // Public videos, but no kids, private or age restricted videos.
-    ANDROID_VR_UNAUTHORIZED(28,
+    ANDROID_VR(28,
             "Quest 3",
             "12",
             "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
@@ -19,7 +19,7 @@ public enum ClientType {
             false
     ),
     // Specific purpose for age restricted videos.
-    ANDROID_VR(28,
+    ANDROID_VR_LOGGED_IN(28,
             "Quest 3",
             "12",
             "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
@@ -92,7 +92,7 @@ public enum ClientType {
     /**
      * If the client can access the API logged in.
      */
-    public final boolean canAuthorize;
+    public final boolean canLogin;
 
     ClientType(int id,
                String deviceModel,
@@ -101,7 +101,7 @@ public enum ClientType {
                @Nullable String androidSdkVersion,
                String clientVersion,
                String clientName,
-               boolean canAuthorize
+               boolean canLogin
     ) {
         this.id = id;
         this.deviceModel = deviceModel;
@@ -110,6 +110,6 @@ public enum ClientType {
         this.androidSdkVersion = androidSdkVersion;
         this.clientVersion = clientVersion;
         this.clientName = clientName;
-        this.canAuthorize = canAuthorize;
+        this.canLogin = canLogin;
     }
 }

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
@@ -8,6 +8,27 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 
 public enum ClientType {
+    // Public videos, but no kids, private or age restricted videos.
+    ANDROID_VR_UNAUTHORIZED(28,
+            "Quest 3",
+            "12",
+            "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
+            "32", // Android 12.1
+            "1.56.21",
+            "ANDROID_VR",
+            false
+    ),
+    // Specific purpose for age restricted videos.
+    ANDROID_VR(28,
+            "Quest 3",
+            "12",
+            "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
+            "32", // Android 12.1
+            "1.56.21",
+            "ANDROID_VR",
+            true
+    ),
+    // Specific for kids videos.
     // https://dumps.tadiphone.dev/dumps/oculus/eureka
     IOS(5,
             // iPhone 15 supports AV1 hardware decoding.
@@ -25,14 +46,9 @@ public enum ClientType {
             null,
             // Version number should be a valid iOS release.
             // https://www.ipa4fun.com/history/185230
-            "19.10.7"
-    ),
-    ANDROID_VR(28,
-            "Quest 3",
-            "12",
-            "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
-            "32", // Android 12.1
-            "1.56.21"
+            "19.10.7",
+            "IOS",
+            false
     );
 
     /**
@@ -44,7 +60,7 @@ public enum ClientType {
     /**
      * Device model, equivalent to {@link Build#MODEL} (System property: ro.product.model)
      */
-    public final String model;
+    public final String deviceModel;
 
     /**
      * Device OS version.
@@ -64,16 +80,36 @@ public enum ClientType {
     public final String androidSdkVersion;
 
     /**
+     * Client name.
+     */
+    public final String clientName;
+
+    /**
      * App version.
      */
-    public final String appVersion;
+    public final String clientVersion;
 
-    ClientType(int id, String model, String osVersion, String userAgent, @Nullable String androidSdkVersion, String appVersion) {
+    /**
+     * If the client can access the API logged in.
+     */
+    public final boolean canAuthorize;
+
+    ClientType(int id,
+               String deviceModel,
+               String osVersion,
+               String userAgent,
+               @Nullable String androidSdkVersion,
+               String clientVersion,
+               String clientName,
+               boolean canAuthorize
+    ) {
         this.id = id;
-        this.model = model;
+        this.deviceModel = deviceModel;
         this.osVersion = osVersion;
         this.userAgent = userAgent;
         this.androidSdkVersion = androidSdkVersion;
-        this.appVersion = appVersion;
+        this.clientVersion = clientVersion;
+        this.clientName = clientName;
+        this.canAuthorize = canAuthorize;
     }
 }

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
@@ -8,18 +8,8 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 
 public enum ClientType {
-    // Public videos, but no kids, private or age restricted videos.
+    // Specific purpose for age restricted, or private videos, because the iOS client is not logged in.
     ANDROID_VR(28,
-            "Quest 3",
-            "12",
-            "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",
-            "32", // Android 12.1
-            "1.56.21",
-            "ANDROID_VR",
-            false
-    ),
-    // Specific purpose for age restricted videos.
-    ANDROID_VR_LOGGED_IN(28,
             "Quest 3",
             "12",
             "com.google.android.apps.youtube.vr.oculus/1.56.21 (Linux; U; Android 12; GB) gzip",

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/requests/PlayerRoutes.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/requests/PlayerRoutes.java
@@ -12,15 +12,13 @@ import app.revanced.extension.youtube.requests.Requester;
 import app.revanced.extension.youtube.requests.Route;
 
 final class PlayerRoutes {
-    private static final String YT_API_URL = "https://youtubei.googleapis.com/youtubei/v1/";
-
     static final Route.CompiledRoute GET_STREAMING_DATA = new Route(
             Route.Method.POST,
             "player" +
                     "?fields=streamingData" +
                     "&alt=proto"
     ).compile();
-
+    private static final String YT_API_URL = "https://youtubei.googleapis.com/youtubei/v1/";
     /**
      * TCP connection and HTTP read timeout
      */
@@ -30,15 +28,15 @@ final class PlayerRoutes {
     }
 
     static String createInnertubeBody(ClientType clientType) {
-    	JSONObject innerTubeBody = new JSONObject();
+        JSONObject innerTubeBody = new JSONObject();
 
         try {
             JSONObject context = new JSONObject();
 
             JSONObject client = new JSONObject();
             client.put("clientName", clientType.name());
-            client.put("clientVersion", clientType.appVersion);
-            client.put("deviceModel", clientType.model);
+            client.put("clientVersion", clientType.clientVersion);
+            client.put("deviceModel", clientType.deviceModel);
             client.put("osVersion", clientType.osVersion);
             if (clientType.androidSdkVersion != null) {
                 client.put("androidSdkVersion", clientType.androidSdkVersion);
@@ -57,7 +55,9 @@ final class PlayerRoutes {
         return innerTubeBody.toString();
     }
 
-    /** @noinspection SameParameterValue*/
+    /**
+     * @noinspection SameParameterValue
+     */
     static HttpURLConnection getPlayerResponseConnectionFromRoute(Route.CompiledRoute route, ClientType clientType) throws IOException {
         var connection = Requester.getConnectionFromCompiledRoute(YT_API_URL, route);
 

--- a/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/requests/StreamingDataRequest.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/youtube/patches/spoof/requests/StreamingDataRequest.java
@@ -125,7 +125,7 @@ public class StreamingDataRequest {
             connection.setReadTimeout(HTTP_TIMEOUT_MILLISECONDS);
 
             for (String key : REQUEST_HEADER_KEYS) {
-                if (!clientType.canAuthorize && key.equals(AUTHORIZATION_HEADER)) {
+                if (!clientType.canLogin && key.equals(AUTHORIZATION_HEADER)) {
                     continue;
                 }
 

--- a/patches/src/main/resources/addresources/values/arrays.xml
+++ b/patches/src/main/resources/addresources/values/arrays.xml
@@ -3,14 +3,14 @@
         <patch id="misc.fix.playback.spoofVideoStreamsPatch">
             <string-array name="revanced_spoof_video_streams_client_entries">
                 <!-- Operating system names are not translatable, so no need to use strings.xml -->
-                <item>Android VR (Logged out)</item>
                 <item>Android VR</item>
+                <item>Android VR (logged in)</item>
                 <item>iOS</item>
             </string-array>
             <string-array name="revanced_spoof_video_streams_client_entry_values">
                 <!-- Enum names from extension -->
-                <item>ANDROID_VR_UNAUTHORIZED</item>
                 <item>ANDROID_VR</item>
+                <item>ANDROID_VR_LOGGED_IN</item>
                 <item>IOS</item>
             </string-array>
         </patch>

--- a/patches/src/main/resources/addresources/values/arrays.xml
+++ b/patches/src/main/resources/addresources/values/arrays.xml
@@ -3,11 +3,13 @@
         <patch id="misc.fix.playback.spoofVideoStreamsPatch">
             <string-array name="revanced_spoof_video_streams_client_entries">
                 <!-- Operating system names are not translatable, so no need to use strings.xml -->
+                <item>Android VR (Logged out)</item>
                 <item>Android VR</item>
                 <item>iOS</item>
             </string-array>
             <string-array name="revanced_spoof_video_streams_client_entry_values">
                 <!-- Enum names from extension -->
+                <item>ANDROID_VR_UNAUTHORIZED</item>
                 <item>ANDROID_VR</item>
                 <item>IOS</item>
             </string-array>
@@ -176,7 +178,7 @@
         </patch>
         <patch id="chat.autoclaim.autoClaimChannelPointsPatch">
         </patch>
-            <patch id="ad.embedded.embeddedAdsPatch">
+        <patch id="ad.embedded.embeddedAdsPatch">
             <string-array name="revanced_block_embedded_ads_entries">
                 <item>@string/revanced_block_embedded_ads_entry_1</item>
                 <item>@string/revanced_block_embedded_ads_entry_2</item>

--- a/patches/src/main/resources/addresources/values/arrays.xml
+++ b/patches/src/main/resources/addresources/values/arrays.xml
@@ -4,13 +4,11 @@
             <string-array name="revanced_spoof_video_streams_client_entries">
                 <!-- Operating system names are not translatable, so no need to use strings.xml -->
                 <item>Android VR</item>
-                <item>Android VR (logged in)</item>
                 <item>iOS</item>
             </string-array>
             <string-array name="revanced_spoof_video_streams_client_entry_values">
                 <!-- Enum names from extension -->
                 <item>ANDROID_VR</item>
-                <item>ANDROID_VR_LOGGED_IN</item>
                 <item>IOS</item>
             </string-array>
         </patch>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -1224,7 +1224,7 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_spoof_video_streams_ios_force_avc_no_hardware_vp9_summary_on">Your device does not have VP9 hardware decoding, and this setting is always on when Client spoofing is enabled</string>
             <string name="revanced_spoof_video_streams_ios_force_avc_user_dialog_message">Enabling this might improve battery life and fix playback stuttering.\n\nAVC has a maximum resolution of 1080p, and video playback will use more internet data than VP9 or AV1.</string>
             <string name="revanced_spoof_video_streams_about_ios_title">iOS spoofing side effects</string>
-            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos will not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
+            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
             <string name="revanced_spoof_video_streams_about_android_vr_title">Android VR spoofing side effects</string>
             <string name="revanced_spoof_video_streams_about_android_vr_summary">• Kids videos may not play\n• Audio track menu is missing\n• Stable volume is not available</string>
         </patch>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -1224,7 +1224,7 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_spoof_video_streams_ios_force_avc_no_hardware_vp9_summary_on">Your device does not have VP9 hardware decoding, and this setting is always on when Client spoofing is enabled</string>
             <string name="revanced_spoof_video_streams_ios_force_avc_user_dialog_message">Enabling this might improve battery life and fix playback stuttering.\n\nAVC has a maximum resolution of 1080p, and video playback will use more internet data than VP9 or AV1.</string>
             <string name="revanced_spoof_video_streams_about_ios_title">iOS spoofing side effects</string>
-            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos will not play\n• Movies or paid videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
+            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos will not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
             <string name="revanced_spoof_video_streams_about_android_vr_title">Android VR spoofing side effects</string>
             <string name="revanced_spoof_video_streams_about_android_vr_summary">• Kids videos may not play\n• Audio track menu is missing\n• Stable volume is not available</string>
         </patch>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -1224,9 +1224,9 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_spoof_video_streams_ios_force_avc_no_hardware_vp9_summary_on">Your device does not have VP9 hardware decoding, and this setting is always on when Client spoofing is enabled</string>
             <string name="revanced_spoof_video_streams_ios_force_avc_user_dialog_message">Enabling this might improve battery life and fix playback stuttering.\n\nAVC has a maximum resolution of 1080p, and video playback will use more internet data than VP9 or AV1.</string>
             <string name="revanced_spoof_video_streams_about_ios_title">iOS spoofing side effects</string>
-            <string name="revanced_spoof_video_streams_about_ios_summary">• Movies or paid videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
+            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos will not play\n• Movies or paid videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
             <string name="revanced_spoof_video_streams_about_android_vr_title">Android VR spoofing side effects</string>
-            <string name="revanced_spoof_video_streams_about_android_vr_summary">• Audio track menu is missing\n• Stable volume is not available</string>
+            <string name="revanced_spoof_video_streams_about_android_vr_summary">• Kids videos may not play\n• Audio track menu is missing\n• Stable volume is not available</string>
         </patch>
     </app>
     <app id="twitch">


### PR DESCRIPTION
YouTube now has restricted the auth token to their respective client. This mean's the Android token can not be used for iOS or VR requests anymore (More info https://github.com/yt-dlp/yt-dlp/issues/11640#issuecomment-2501049515).

Private or kids' videos can not be played without logging in.

The only solution here is to ask the user to log in, or somehow handle the login to other clients when the user logs into GmsCore.

Currently, VR seems to work with the Android auth token. This means, that private videos will work. What won't work is private kids videos, because VR is the only authorized client currently,  and that one can't play kids videos.