### PR TITLE
fix(YouTube - Spoof video streams): Enable opus codec by updating iOS client version

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/spoof/ClientType.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 
 public enum ClientType {
     // Specific purpose for age restricted, or private videos, because the iOS client is not logged in.
+    // https://dumps.tadiphone.dev/dumps/oculus/eureka
     ANDROID_VR(28,
             "Quest 3",
             "12",
@@ -19,7 +20,6 @@ public enum ClientType {
             true
     ),
     // Specific for kids videos.
-    // https://dumps.tadiphone.dev/dumps/oculus/eureka
     IOS(5,
             // iPhone 15 supports AV1 hardware decoding.
             // Only use if this Android device also has hardware decoding.
@@ -31,12 +31,12 @@ public enum ClientType {
                     ? "17.5.1.21F90"
                     : "13.7.17H35",
             allowVP9()
-                    ? "com.google.ios.youtube/19.10.7 (iPhone; U; CPU iOS 17_5_1 like Mac OS X)"
-                    : "com.google.ios.youtube/19.10.7 (iPhone; U; CPU iOS 13_7 like Mac OS X)",
+                    ? "com.google.ios.youtube/19.47.7 (iPhone; U; CPU iOS 17_5_1 like Mac OS X)"
+                    : "com.google.ios.youtube/19.47.7 (iPhone; U; CPU iOS 13_7 like Mac OS X)",
             null,
             // Version number should be a valid iOS release.
             // https://www.ipa4fun.com/history/185230
-            "19.10.7",
+            "19.47.7",
             "IOS",
             false
     );

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -1225,7 +1225,7 @@ This is because Crowdin requires temporarily flattening this file and removing t
             <string name="revanced_spoof_video_streams_ios_force_avc_no_hardware_vp9_summary_on">Your device does not have VP9 hardware decoding, and this setting is always on when Client spoofing is enabled</string>
             <string name="revanced_spoof_video_streams_ios_force_avc_user_dialog_message">Enabling this might improve battery life and fix playback stuttering.\n\nAVC has a maximum resolution of 1080p, and video playback will use more internet data than VP9 or AV1.</string>
             <string name="revanced_spoof_video_streams_about_ios_title">iOS spoofing side effects</string>
-            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early\n• No opus audio codec</string>
+            <string name="revanced_spoof_video_streams_about_ios_summary">• Private kids videos may not play\n• Livestreams start from the beginning\n• Videos may end 1 second early</string>
             <string name="revanced_spoof_video_streams_about_android_vr_title">Android VR spoofing side effects</string>
             <string name="revanced_spoof_video_streams_about_android_vr_summary">• Kids videos may not play\n• Audio track menu is missing\n• Stable volume is not available</string>
         </patch>


### PR DESCRIPTION
Update the hard-coded iOS client version to enable Opus codec on iOS spoofing.
This resolves one of the side effects of iOS spoofing.

This was found by Oxrxl and inotia00.
However I guess they will not PR to ReVanced, but I still think would like to reflect this to ReVanced.

References:

- https://github.com/ReVanced/revanced-patches/issues/3756
- https://github.com/inotia00/ReVanced_Extended/issues/2480
- https://github.com/inotia00/revanced-integrations/commit/805fbe9beb1575453a7447eff601d43bd1641271

Before PR: Audio codec is mp4a.
![Screenshot_20241207-021422_YouTube ReVanced](https://github.com/user-attachments/assets/59ca5fc9-11c8-42a0-8162-2a4e8ffe17a3)
Afret PR: Audio codec is opus.
![Screenshot_20241207-022123_YouTube ReVanced](https://github.com/user-attachments/assets/156f344f-058d-46bc-a901-3d5f88d276cd)

Also I tested that opus codec is available on hardware AV1 decoding with another device.