### PR TITLE
feat(Twitch): Make patches compatible with latest versions

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/twitch/ad/audio/AudioAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/ad/audio/AudioAdsPatch.kt
@@ -21,7 +21,7 @@ val audioAdsPatch = bytecodePatch(
         addResourcesPatch,
     )
 
-    compatibleWith("tv.twitch.android.app"("15.4.1", "16.1.0", "16.9.1"))
+    compatibleWith("tv.twitch.android.app")
 
     execute {
         addResources("twitch", "ad.audio.audioAdsPatch")

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/EmbeddedAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/EmbeddedAdsPatch.kt
@@ -19,7 +19,7 @@ val embeddedAdsPatch = bytecodePatch(
         settingsPatch,
     )
 
-    compatibleWith("tv.twitch.android.app"("15.4.1", "16.1.0", "16.9.1"))
+    compatibleWith("tv.twitch.android.app")
 
     execute {
         addResources("twitch", "ad.embedded.embeddedAdsPatch")

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/Fingerprints.kt
@@ -4,6 +4,6 @@ import app.revanced.patcher.fingerprint
 
 internal val createsUsherClientFingerprint = fingerprint {
     custom { method, _ ->
-        method.definingClass.endsWith("Ltv/twitch/android/network/OkHttpClientFactory;") && method.name == "buildOkHttpClient"
+        method.name == "buildOkHttpClient" && method.definingClass.endsWith("Ltv/twitch/android/network/OkHttpClientFactory;")
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/ad/video/VideoAdsPatch.kt
@@ -141,14 +141,15 @@ val videoAdsPatch = bytecodePatch(
                 )
 
                 // Spoof showAds JSON field.
-                contentConfigShowAdsFingerprint.method.addInstructions(
+                // Late versions of the app don't have the method anymore.
+                contentConfigShowAdsFingerprint.methodOrNull?.addInstructions(
                     0,
                     """
-                    ${createConditionInstructions("v0")}
-                    const/4 v0, 0
-                    :$skipLabelName
-                    return v0
-                """,
+                        ${createConditionInstructions("v0")}
+                        const/4 v0, 0
+                        :$skipLabelName
+                        return v0
+                    """,
                 )
             }
         },

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/ShowDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/ShowDeletedMessagesPatch.kt
@@ -22,7 +22,7 @@ val showDeletedMessagesPatch = bytecodePatch(
         addResourcesPatch,
     )
 
-    compatibleWith("tv.twitch.android.app"("15.4.1", "16.1.0", "16.9.1"))
+    compatibleWith("tv.twitch.android.app")
 
     fun createSpoilerConditionInstructions(register: String = "v0") = """
         invoke-static {}, Lapp/revanced/extension/twitch/patches/ShowDeletedMessagesPatch;->shouldUseSpoiler()Z

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/AutoClaimChannelPointsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/AutoClaimChannelPointsPatch.kt
@@ -20,7 +20,7 @@ val autoClaimChannelPointsPatch = bytecodePatch(
         addResourcesPatch,
     )
 
-    compatibleWith("tv.twitch.android.app"("15.4.1", "16.1.0", "16.9.1"))
+    compatibleWith("tv.twitch.android.app")
 
     execute {
         addResources("twitch", "chat.autoclaim.autoClaimChannelPointsPatch")

--- a/patches/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitch/misc/settings/SettingsPatch.kt
@@ -48,13 +48,7 @@ val settingsPatch = bytecodePatch(
         settingsPatch(preferences = preferences),
     )
 
-    compatibleWith(
-        "tv.twitch.android.app"(
-            "15.4.1",
-            "16.1.0",
-            "16.9.1",
-        ),
-    )
+    compatibleWith("tv.twitch.android.app")
 
     execute {
         addResources("twitch", "misc.settings.settingsPatch")


### PR DESCRIPTION
This fixes patching errors, however late versions of Twitch are only bundles and the last ones that are APK fail to compile due to resources being decoded incorrectly. Neither of which is matter for the patches though.