### PR TITLE
fix(YouTube - Hide feed components): Remove obsolete `Hide search result shelf header` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -36,7 +36,6 @@ public final class LayoutComponentsFilter extends Filter {
     );
 
     private final StringTrieSearch exceptions = new StringTrieSearch();
-    private final StringFilterGroup searchResultShelfHeader;
     private final StringFilterGroup inFeedSurvey;
     private final StringFilterGroup notifyMe;
     private final StringFilterGroup expandableMetadata;
@@ -194,11 +193,6 @@ public final class LayoutComponentsFilter extends Filter {
                 "timed_reaction"
         );
 
-        searchResultShelfHeader = new StringFilterGroup(
-                Settings.HIDE_SEARCH_RESULT_SHELF_HEADER,
-                "shelf_header.eml"
-        );
-
         notifyMe = new StringFilterGroup(
                 Settings.HIDE_NOTIFY_ME_BUTTON,
                 "set_reminder_button"
@@ -323,9 +317,6 @@ public final class LayoutComponentsFilter extends Filter {
 
             return false;
         }
-
-        // TODO: This also hides the feed Shorts shelf header
-        if (matchedGroup == searchResultShelfHeader && contentIndex != 0) return false;
 
         if (matchedGroup == horizontalShelves) {
             if (contentIndex == 0 && hideShelves()) {

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -91,7 +91,6 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_NOTIFY_ME_BUTTON = new BooleanSetting("revanced_hide_notify_me_button", TRUE);
     public static final BooleanSetting HIDE_PLAYABLES = new BooleanSetting("revanced_hide_playables", TRUE);
     public static final BooleanSetting HIDE_SEARCH_RESULT_RECOMMENDATIONS = new BooleanSetting("revanced_hide_search_result_recommendations", TRUE);
-    public static final BooleanSetting HIDE_SEARCH_RESULT_SHELF_HEADER = new BooleanSetting("revanced_hide_search_result_shelf_header", FALSE);
     public static final BooleanSetting HIDE_SHOW_MORE_BUTTON = new BooleanSetting("revanced_hide_show_more_button", TRUE, true);
     // Alternative thumbnails
     public static final EnumSetting<ThumbnailOption> ALT_THUMBNAIL_HOME = new EnumSetting<>("revanced_alt_thumbnail_home", ThumbnailOption.ORIGINAL);

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -222,7 +222,6 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("revanced_hide_notify_me_button"),
             SwitchPreference("revanced_hide_playables"),
             SwitchPreference("revanced_hide_search_result_recommendations"),
-            SwitchPreference("revanced_hide_search_result_shelf_header"),
             SwitchPreference("revanced_hide_show_more_button"),
             SwitchPreference("revanced_hide_doodles"),
         )

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -158,9 +158,6 @@ You will not be notified of any unexpected events."</string>
             <string name="revanced_hide_timed_reactions_title">Hide timed reactions</string>
             <string name="revanced_hide_timed_reactions_summary_on">Timed reactions are hidden</string>
             <string name="revanced_hide_timed_reactions_summary_off">Timed reactions are shown</string>
-            <string name="revanced_hide_search_result_shelf_header_title">Hide search result shelf header</string>
-            <string name="revanced_hide_search_result_shelf_header_summary_on">Shelf header is hidden</string>
-            <string name="revanced_hide_search_result_shelf_header_summary_off">Shelf header is shown</string>
             <string name="revanced_hide_channel_guidelines_title">Hide channel guidelines</string>
             <string name="revanced_hide_channel_guidelines_summary_on">Channel guidelines are hidden</string>
             <string name="revanced_hide_channel_guidelines_summary_off">Channel guidelines are shown</string>


### PR DESCRIPTION
Closes #8.