### PR TITLE
ci: Don't upload strings to Crowdin when pulling

### DIFF
--- a/.github/workflows/pull_strings.yml
+++ b/.github/workflows/pull_strings.yml
@@ -23,6 +23,7 @@ jobs:
         uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
+          upload_sources: false
           download_translations: true
           localization_branch_name: feat/translations
           create_pull_request: false
@@ -39,4 +40,3 @@ jobs:
           destination_branch: dev
           pr_title: "chore: Sync translations"
           pr_body: "Sync translations from [crowdin.com/project/revanced](https://crowdin.com/project/revanced)"
-          pr_draft: true


### PR DESCRIPTION
Turns off pushing of strings during pull action.

Without this, during a pull it's also pushing:
https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582

```
STARTING CROWDIN ACTION
(https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582#step:5:31)
UPLOAD SOURCES
(https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582#step:5:32)
✔️  Fetching project info
(https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582#step:5:33)
✔️  File 'strings.xml'
DOWNLOAD TRANSLATIONS
(https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582#step:5:42)
✔️  Fetching project info
(https://github.com/ReVanced/revanced-patches/actions/runs/12392938624/job/34593159582#step:5:43)
✔️  Building ZIP archive with the latest translations
```