### PR TITLE
chore: Clarify reddit Spoof client app instructions

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/SpoofClientPatch.kt
@@ -27,7 +27,9 @@ fun spoofClientPatch(
             "The Reddit OAuth client ID. " +
                 "You can get your client ID from https://www.reddit.com/prefs/apps. " +
                 "The application type has to be \"Installed app\" " +
-                "and the redirect URI has to be set to \"$redirectUri\".",
+                "and the redirect URI has to be set to \"$redirectUri\"." +
+                "You can input the client ID in this text box" +
+                "(This is NOT a file selection despite Kebab menu.)",
             true,
         ),
     )


### PR DESCRIPTION
With the kebab menu on the side asking for a file/folder. It can be easily misunderstood by users that this is a file selection prompt. When it actually is a string field asking for the client ID.

This can be even more confusing to users who have their client id inside the ``reddit_client_id_revanced.txt`` file from previous version of this patch. (and from various out of date online instructions)

Preferably, this would be fixed in the app by removing the Kebab menu or making it input the file contents instead. But I am not an android dev.

Note: IDK if this is a "chore" I never experienced pr naming guidelines like these.