### PR TITLE
fix(YouTube - Hide ads): `Hide Visit store button in channel pages` not working

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
@@ -114,7 +114,8 @@ public final class AdsFilter extends Filter {
 
         channelProfile = new StringFilterGroup(
                 null,
-                "channel_profile.eml"
+                "channel_profile.eml",
+                "page_header.eml"
         );
 
         playerShoppingShelf = new StringFilterGroup(

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
@@ -112,13 +112,7 @@ public final class AdsFilter extends Filter {
                 "expandable_list"
         );
 
-        channelProfile = new StringFilterGroup(
-                null,
-                "channel_profile.eml",
-                "page_header.eml"
-        );
-
-        playerShoppingShelf = new StringFilterGroup(
+                playerShoppingShelf = new StringFilterGroup(
                 null,
                 "horizontal_shelf.eml"
         );
@@ -126,6 +120,12 @@ public final class AdsFilter extends Filter {
         playerShoppingShelfBuffer = new ByteArrayFilterGroup(
                 Settings.HIDE_PLAYER_STORE_SHELF,
                 "shopping_item_card_list.eml"
+        );
+
+        channelProfile = new StringFilterGroup(
+                null,
+                "channel_profile.eml",
+                "page_header.eml"
         );
 
         visitStoreButton = new ByteArrayFilterGroup(

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
@@ -111,8 +111,8 @@ public final class AdsFilter extends Filter {
                 Settings.HIDE_SHOPPING_LINKS,
                 "expandable_list"
         );
-
-                playerShoppingShelf = new StringFilterGroup(
+        
+        playerShoppingShelf = new StringFilterGroup(
                 null,
                 "horizontal_shelf.eml"
         );


### PR DESCRIPTION
Due to https://github.com/ReVanced/revanced-patches/issues/3058#issuecomment-2159898118.

```kotlin
01-25 16:50:56.584 21578 21746 D revanced: LithoFilterPatch: Searching ID: null Path: video_lockup_with_attachment.eml|9fc404f360dd4a22|CellType|video_lockup_attachments.eml|5beff7dc06a8170e|ContainerType| BufferStrings: 
01-25 16:50:56.585 21578 21578 D revanced: LithoFilterPatch: Searching ID: null Path: page_header.eml|ad498a1d21e54bc|ContainerType|ContainerType|ContainerType|flexible_actions_channels.eml|2743dac01273acff|channel_action_buttons_phone.eml|72946b23a49322d6|ContainerType|button.eml|3f079e0013cfeec8|ContainerType| BufferStrings: Visit store❙sans-serif❙eml.header_store_button❙Visit store❙UCBJycsmduvYEL83R_U4JriQ❙EgVzdG9yZfIGBBICKgA%3D"❙/@mkbhd❙
``` 