### PR TITLE
fix(YouTube - Hide ads): Hide Visit store button in channel pages not working

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/AdsFilter.java
@@ -137,7 +137,8 @@ public final class AdsFilter extends Filter {
 
         channelProfile = new StringFilterGroup(
                 null,
-                "channel_profile.eml"
+                "channel_profile.eml",
+                "page_header.eml"
         );
 
         visitStoreButton = new ByteArrayFilterGroup(


### PR DESCRIPTION
Due to https://github.com/ReVanced/revanced-patches/issues/3058#issuecomment-2159898118.

```kotlin
01-25 16:50:56.585 21578 21578 D revanced: LithoFilterPatch: Searching ID: null Path: page_header.eml|ad498a1d21e54bc|ContainerType|ContainerType|ContainerType|flexible_actions_channels.eml|2743dac01273acff|channel_action_buttons_phone.eml|72946b23a49322d6|ContainerType|button.eml|3f079e0013cfeec8|ContainerType| BufferStrings: Visit store❙sans-serif❙eml.header_store_button❙Visit store❙UCBJycsmduvYEL83R_U4JriQ❙EgVzdG9yZfIGBBICKgA%3D"❙/@mkbhd❙
``` 