### PR TITLE
fix(SwissId - Play integrity Removal): add compatibility

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/swissid/integritycheck/RemoveGooglePlayIntegrityCheckPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/swissid/integritycheck/RemoveGooglePlayIntegrityCheckPatch.kt
@@ -15,7 +15,7 @@ val removeGooglePlayIntegrityCheckPatch = bytecodePatch(
     description = "Removes the Google Play Integrity check. With this it's possible to use SwissID on custom ROMS." +
         "If the device is rooted, root permissions must be hidden from the app.",
 ) {
-    compatibleWith("com.swisssign.swissid.mobile")
+    compatibleWith("com.swisssign.swissid.mobile"("5.2.9"))
 
     execute {
         checkIntegrityFingerprint.method.addInstructions(


### PR DESCRIPTION
Adds compatibility for the patch to remove the Play integrity on the SwissId app.

I was trying many old versions where the patch couldn't be applied.