### PR TITLE
fix(Twitter - Hide recommended users): add new timeline entryId prefix

### DIFF
--- a/extensions/twitter/src/main/java/app/revanced/twitter/patches/hook/twifucker/TwiFucker.kt
+++ b/extensions/twitter/src/main/java/app/revanced/twitter/patches/hook/twifucker/TwiFucker.kt
@@ -163,7 +163,7 @@ internal object TwiFucker {
 
     private fun JSONObject.entryIsWhoToFollow(): Boolean =
         optString("entryId").let {
-            it.startsWith("whoToFollow-") || it.startsWith("who-to-follow-") || it.startsWith("connect-module-")
+            it.startsWith("whoToFollow-") || it.startsWith("who-to-follow-") || it.startsWith("connect-module-") || it.startsWith("who-to-subscribe-")
         }
 
     private fun JSONObject.itemContainsPromotedUser(): Boolean =


### PR DESCRIPTION
twitter has started (a long ago) to use `who-to-subscribe-` prefix instead of `who-to-follow-`

this adds the new prefix, so it is properly blocked again

[!fixes ](https://github.com/ReVanced/revanced-patches/issues/521)