### PR TITLE
feat(Proton Mail):add `Remove 'sent from' signature` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -388,6 +388,10 @@ public final class app/revanced/patches/pixiv/ads/HideAdsPatchKt {
 	public static final fun getHideAdsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/protonmail/footer/RemoveMobileFooterPatchKt {
+	public static final fun getRemoveMobileFooterPatch ()Lapp/revanced/patcher/patch/ResourcePatch;
+}
+
 public final class app/revanced/patches/rar/misc/annoyances/purchasereminder/HidePurchaseReminderPatchKt {
 	public static final fun getHidePurchaseReminderPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/protonmail/footer/RemoveMobileFooterPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/protonmail/footer/RemoveMobileFooterPatch.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.protonmail.footer
+
+import app.revanced.patcher.patch.resourcePatch
+import org.w3c.dom.Element
+
+@Suppress("unused")
+val removeMobileFooterPatch = resourcePatch(
+    name = "Remove 'sent from' signature",
+    description = "Removes the 'Sent from Proton Mail mobile' signature from emails.",
+) {
+    execute {
+        document("res/values/strings.xml").use { document ->
+            val stringElements = document.getElementsByTagName("string")
+            val element = (0 until stringElements.length)
+                .mapNotNull { stringElements.item(it) as? Element }
+                .find { it.getAttribute("name") == "mail_settings_identity_mobile_footer_default_free" }
+
+            element?.textContent = ""
+        }
+    }
+}


### PR DESCRIPTION
This patch removes the "Sent from Proton Mail Android" text from the compose window of the Proton Mail app.
Closes #4458 