### PR TITLE
Add max volume customization patch

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -315,6 +315,7 @@ public class Settings extends BaseSettings {
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final IntegerSetting SWIPE_MAGNITUDE_THRESHOLD = new IntegerSetting("revanced_swipe_threshold", 30, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
+    public static final IntegerSetting SWIPE_MAX_VOLUME = new IntegerSetting("revanced_swipe_max_volume", 0, true, parent(SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_SHOW_CIRCULAR_OVERLAY = new BooleanSetting("revanced_swipe_show_circular_overlay", FALSE, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_OVERLAY_MINIMAL_STYLE = new BooleanSetting("revanced_swipe_overlay_minimal_style", FALSE, true,

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -60,6 +60,12 @@ class SwipeControlsConfigurationProvider(
      */
     val swipeMagnitudeThreshold: Int
         get() = Settings.SWIPE_MAGNITUDE_THRESHOLD.get()
+
+    /**
+     * number of volume steps set by user in settings
+     * */
+    val maxVolume: Int
+        get() = Settings.SWIPE_MAX_VOLUME.get()
 //endregion
 
 //region overlay adjustments

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
@@ -200,7 +200,7 @@ class SwipeControlsHostActivity : Activity() {
      */
     private fun createAudioController() =
         if (config.enableVolumeControls) {
-            AudioVolumeController(this)
+            AudioVolumeController(this, config.maxVolume)
         } else {
             null
         }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -47,6 +47,7 @@ private val swipeControlsResourcePatch = resourcePatch {
             TextPreference("revanced_swipe_overlay_background_opacity", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_overlay_timeout", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_threshold", inputType = InputType.NUMBER),
+            TextPreference("revanced_swipe_max_volume", inputType = InputType.NUMBER),
         )
 
         copyResources(

--- a/patches/src/main/resources/addresources/values-pl-rPL/strings.xml
+++ b/patches/src/main/resources/addresources/values-pl-rPL/strings.xml
@@ -509,6 +509,8 @@ Dostosuj głośność, przesuwając pionowo po prawej stronie ekranu"</string>
   <string name="revanced_swipe_overlay_background_opacity_invalid_toast">Przezroczystość przesuwania musi być między 0 a 100</string>
   <string name="revanced_swipe_threshold_title">Minimalna długość przesunięcia</string>
   <string name="revanced_swipe_threshold_summary">Wartość wymagana do wykonania gestu przesunięcia</string>
+  <string name="revanced_swipe_max_volume_title">Maksymalna głośność</string>
+  <string name="revanced_swipe_max_volume_summary">Ilość kroków głośności przy presuwaniu. 0 oznacza wartość systemową</string>
   <string name="revanced_swipe_show_circular_overlay_title">Pokaż okrągłą nakładkę</string>
   <string name="revanced_swipe_show_circular_overlay_summary_on">Wyświetlana jest okrągła nakładka</string>
   <string name="revanced_swipe_show_circular_overlay_summary_off">Wyświetlana jest pozioma nakładka</string>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -514,6 +514,8 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
             <string name="revanced_swipe_overlay_background_opacity_invalid_toast">Swipe opacity must be between 0-100</string>
             <string name="revanced_swipe_threshold_title">Swipe magnitude threshold</string>
             <string name="revanced_swipe_threshold_summary">The amount of threshold for swipe to occur</string>
+            <string name="revanced_swipe_max_volume_title">Maximum volume</string>
+            <string name="revanced_swipe_max_volume_summary">Volume steps when swiping. 0 means the system default</string>
             <string name="revanced_swipe_show_circular_overlay_title">Show circular overlay</string>
             <string name="revanced_swipe_show_circular_overlay_summary_on">Circular overlay is shown</string>
             <string name="revanced_swipe_show_circular_overlay_summary_off">Horizontal overlay is shown</string>


### PR DESCRIPTION
It's super annoying to scroll through 160 volume levels, so I've added an option to customize the number of volume levels when swiping.

Fixes #1646

Btw, `audioManager.getStreamMaxVolume(targetStream)` returns different values on my device. With root/mount method it returns 160, but with the microg method, it's just 16.