### PR TITLE
feat(YouTube - Remember video quality): Separate settings for Shorts

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -52,6 +52,10 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting REMEMBER_VIDEO_QUALITY_LAST_SELECTED = new BooleanSetting("revanced_remember_video_quality_last_selected", FALSE);
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_WIFI = new IntegerSetting("revanced_video_quality_default_wifi", -2);
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_MOBILE = new IntegerSetting("revanced_video_quality_default_mobile", -2);
+    public static final BooleanSetting VIDEO_QUALITY_SEPARATE_SHORTS = new BooleanSetting("revanced_video_quality_separate_shorts", false);
+    public static final BooleanSetting REMEMBER_SHORTS_QUALITY_LAST_SELECTED = new BooleanSetting("revanced_remember_shorts_quality_last_selected", FALSE, parent(VIDEO_QUALITY_SEPARATE_SHORTS));
+    public static final IntegerSetting VIDEO_QUALITY_DEFAULT_WIFI_SHORTS = new IntegerSetting("revanced_video_quality_default_wifi_shorts", -2, parent(VIDEO_QUALITY_SEPARATE_SHORTS));
+    public static final IntegerSetting VIDEO_QUALITY_DEFAULT_MOBILE_SHORTS = new IntegerSetting("revanced_video_quality_default_mobile_shorts", -2, parent(VIDEO_QUALITY_SEPARATE_SHORTS));
     // Speed
     public static final FloatSetting SPEED_TAP_AND_HOLD = new FloatSetting("revanced_speed_tap_and_hold", 2.0f, true);
     public static final BooleanSetting REMEMBER_PLAYBACK_SPEED_LAST_SELECTED = new BooleanSetting("revanced_remember_playback_speed_last_selected", FALSE);

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/video/quality/RememberVideoQualityPatch.kt
@@ -8,8 +8,11 @@ import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.patches.all.misc.resources.addResources
 import app.revanced.patches.all.misc.resources.addResourcesPatch
 import app.revanced.patches.shared.misc.settings.preference.ListPreference
+import app.revanced.patches.shared.misc.settings.preference.PreferenceScreenPreference
+import app.revanced.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
 import app.revanced.patches.shared.misc.settings.preference.SwitchPreference
 import app.revanced.patches.youtube.misc.extension.sharedExtensionPatch
+import app.revanced.patches.youtube.misc.playertype.playerTypeHookPatch
 import app.revanced.patches.youtube.misc.settings.PreferenceScreen
 import app.revanced.patches.youtube.misc.settings.settingsPatch
 import app.revanced.patches.youtube.shared.newVideoQualityChangedFingerprint
@@ -29,6 +32,7 @@ val rememberVideoQualityPatch = bytecodePatch(
     dependsOn(
         sharedExtensionPatch,
         videoInformationPatch,
+        playerTypeHookPatch,
         settingsPatch,
         addResourcesPatch,
     )
@@ -49,19 +53,40 @@ val rememberVideoQualityPatch = bytecodePatch(
         addResources("youtube", "video.quality.rememberVideoQualityPatch")
 
         PreferenceScreen.VIDEO.addPreferences(
-            SwitchPreference("revanced_remember_video_quality_last_selected"),
-            ListPreference(
-                key = "revanced_video_quality_default_wifi",
+            PreferenceScreenPreference(
+                key = "revanced_video_quality_screen",
                 summaryKey = null,
-                entriesKey = "revanced_video_quality_default_entries",
-                entryValuesKey = "revanced_video_quality_default_entry_values",
-            ),
-            ListPreference(
-                key = "revanced_video_quality_default_mobile",
-                summaryKey = null,
-                entriesKey = "revanced_video_quality_default_entries",
-                entryValuesKey = "revanced_video_quality_default_entry_values",
-            ),
+                sorting = Sorting.UNSORTED,
+                preferences = setOf(
+                    SwitchPreference("revanced_remember_video_quality_last_selected"),
+                    ListPreference(
+                        key = "revanced_video_quality_default_wifi",
+                        summaryKey = null,
+                        entriesKey = "revanced_video_quality_default_entries",
+                        entryValuesKey = "revanced_video_quality_default_entry_values",
+                    ),
+                    ListPreference(
+                        key = "revanced_video_quality_default_mobile",
+                        summaryKey = null,
+                        entriesKey = "revanced_video_quality_default_entries",
+                        entryValuesKey = "revanced_video_quality_default_entry_values",
+                    ),
+                    SwitchPreference("revanced_video_quality_separate_shorts"),
+                    SwitchPreference("revanced_remember_shorts_quality_last_selected"),
+                    ListPreference(
+                        key = "revanced_video_quality_default_wifi_shorts",
+                        summaryKey = null,
+                        entriesKey = "revanced_video_quality_default_entries",
+                        entryValuesKey = "revanced_video_quality_default_entry_values",
+                    ),
+                    ListPreference(
+                        key = "revanced_video_quality_default_mobile_shorts",
+                        summaryKey = null,
+                        entriesKey = "revanced_video_quality_default_entries",
+                        entryValuesKey = "revanced_video_quality_default_entry_values",
+                    ),
+                )
+            )
         )
 
         /*

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -1375,15 +1375,25 @@ Enabling this can unlock higher video qualities"</string>
         </patch>
         <patch id="video.quality.rememberVideoQualityPatch">
             <!-- Translations should use the same text as revanced_custom_playback_speeds_auto -->
+            <string name="revanced_video_quality_screen_title">Video quality</string>
             <string name="revanced_video_quality_default_entry_1">Auto</string>
             <string name="revanced_remember_video_quality_last_selected_title">Remember video quality changes</string>
             <string name="revanced_remember_video_quality_last_selected_summary_on">Quality changes apply to all videos</string>
             <string name="revanced_remember_video_quality_last_selected_summary_off">Quality changes only apply to the current video</string>
             <string name="revanced_video_quality_default_wifi_title">Default video quality on Wi-Fi network</string>
             <string name="revanced_video_quality_default_mobile_title">Default video quality on mobile network</string>
+            <string name="revanced_video_quality_separate_shorts_title">Separate Shorts quality settings</string>
+            <string name="revanced_video_quality_separate_shorts_summary_on">Shorts quality settings are saved separately</string>
+            <string name="revanced_video_quality_separate_shorts_summary_off">Shorts and regular videos use the same settings</string>
+            <string name="revanced_remember_shorts_quality_last_selected_title">Remember Shorts quality changes</string>
+            <string name="revanced_remember_shorts_quality_last_selected_summary_on">Quality changes apply to all Shorts videos</string>
+            <string name="revanced_remember_shorts_quality_last_selected_summary_off">Quality changes only apply to the current Shorts video</string>
+            <string name="revanced_video_quality_default_wifi_shorts_title">Default Shorts quality on Wi-Fi network</string>
+            <string name="revanced_video_quality_default_mobile_shorts_title">Default Shorts quality on mobile network</string>
             <string name="revanced_remember_video_quality_mobile">mobile</string>
             <string name="revanced_remember_video_quality_wifi">wifi</string>
             <string name="revanced_remember_video_quality_toast">Changed default %1$s quality to: %2$s</string>
+            <string name="revanced_remember_video_quality_toast_shorts">Changed Shorts %1$s quality to: %2$s</string>
         </patch>
         <patch id="video.speed.button.playbackSpeedButtonPatch">
             <string name="revanced_playback_speed_dialog_button_title">Show speed dialog button</string>


### PR DESCRIPTION
Adds options to use separate quality preferences for Shorts.

This also lets users disable the patch specifically for Shorts.

## All changes
- Added a new "Video quality" preference screen to video settings
- Added 3 options to the new video quality preference screen:
  - Separate Shorts quality settings: when disabled (default), both Shorts and regular videos use the regular preferences
  - Remember Shorts quality changes
  - Default Shorts quality on Wi-Fi network
  - Default Shorts quality on mobile network
- Moved default video quality options and "remember video quality changes" switch to the new video quality preference screen

![Screenshot_20250305-143110_YouTube](https://github.com/user-attachments/assets/6b14e8cc-772b-4d63-9dd2-c5857df51585)
![Screenshot_20250305-143120_YouTube](https://github.com/user-attachments/assets/7887e1e8-f80e-49c9-a60e-0bb705cac6a5)
