### PR TITLE
fix(Boost for Reddit - Spoof client ID): Add additional patch to spoof Boost for Reddit's user agent and redirect URI

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -421,6 +421,7 @@ public final class app/revanced/patches/reddit/customclients/FixSLinksPatchKt {
 
 public final class app/revanced/patches/reddit/customclients/SpoofClientPatchKt {
 	public static final fun spoofClientPatch (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lapp/revanced/patcher/patch/BytecodePatch;
+	public static final fun spoofClientPatch (Lkotlin/jvm/functions/Function4;)Lapp/revanced/patcher/patch/BytecodePatch;
 	public static synthetic fun spoofClientPatch$default (Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/revanced/patcher/patch/BytecodePatch;
 }
 

--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/SpoofClientPatch.kt
@@ -32,3 +32,51 @@ fun spoofClientPatch(
         ),
     )
 }
+
+/**
+ * Base class for patches that spoof the Reddit client.
+ *
+ * @param block The patch block. It is called with the client ID option, redirect URI
+ * option and user agent option.
+ */
+fun spoofClientPatch(
+    block: BytecodePatchBuilder.(
+        clientIdOption: Option<String>,
+        redirectUriOption: Option<String>,
+        userAgentOption: Option<String>,
+    ) -> Unit,
+) = bytecodePatch(
+    name = "Spoof client",
+    description = "Restores functionality of the app by using custom client ID.",
+) {
+    block(
+        stringOption(
+            "client-id",
+            null,
+            null,
+            "OAuth client ID",
+            "The Reddit OAuth client ID. " +
+                "You can get your client ID from https://www.reddit.com/prefs/apps. " +
+                "The application type has to be \"Installed app\" and the redirect " +
+                "URI has to match the value provided for the \"Redirect URI\" option.",
+            true,
+        ),
+        stringOption(
+            "redirect-uri",
+            "http://127.0.0.1:8080",
+            null,
+            "Redirect URI",
+            "The Reddit OAuth redirect URI. Should be a valid URI.",
+            true,
+        ),
+        stringOption(
+            "user-agent",
+            null,
+            null,
+            "User agent",
+            "The app's user agent. User agent should be in the format " +
+                    "\"<platform>:<app id>:<version> (by /u/<username>)\".",
+            true,
+        )
+    )
+}

--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/Fingerprints.kt
@@ -13,3 +13,21 @@ internal val getClientIdFingerprint = fingerprint {
         method.name == "getClientId"
     }
 }
+
+internal val loginActivityOnCreateFingerprint = fingerprint {
+    strings("http://rubenmayayo.com")
+    custom { method, classDef ->
+        if (!classDef.endsWith("LoginActivity;")) return@custom false
+
+        method.name == "onCreate"
+    }
+}
+
+internal val loginActivityAShouldOverrideUrlLoadingFingerprint = fingerprint {
+    strings("http://rubenmayayo.com")
+    custom { method, classDef ->
+        if (!classDef.endsWith("LoginActivity${'$'}a;")) return@custom false
+
+        method.name == "shouldOverrideUrlLoading"
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
@@ -1,15 +1,15 @@
 package app.revanced.patches.reddit.customclients.boostforreddit.api
 
+import app.revanced.patcher.Fingerprint
+import app.revanced.patcher.Match
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
-import app.revanced.patches.reddit.customclients.spoofClientPatch
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-
 import app.revanced.patcher.patch.BytecodePatchBuilder
 import app.revanced.patcher.patch.Option
 import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.patcher.patch.stringOption
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Suppress("unused")
 val spoofClientPatch = bytecodePatch(
@@ -17,16 +17,29 @@ val spoofClientPatch = bytecodePatch(
 ) {
     compatibleWith("com.rubenmayayo.reddit")
 
-    val redirectUri = "http://rubenmayayo.com"
+    val redirectUri by stringOption(
+        "redirect-uri",
+        "http://127.0.0.1:8080",
+        null,
+        "Redirect URI",
+        "The Reddit OAuth redirect URI. " +
+                "If you don't know what this means, don't change it. " +
+                "Make sure you update the \"Installed app\" you created at " +
+                "https://www.reddit.com/prefs/apps to have the same redirect URI " +
+                "as what you put here.",
+        true,
+    )
+
     val clientId by stringOption(
         "client-id",
         null,
         null,
         "OAuth client ID",
         "The Reddit OAuth client ID. " +
-                "You can get your client ID from https://www.reddit.com/prefs/apps. " +
-                "The application type has to be \"Installed app\" " +
-                "and the redirect URI has to be set to \"$redirectUri\".",
+                "You can get a client ID by creating an \"Installed app\" at " +
+                "https://www.reddit.com/prefs/apps. The redirect URI should be set to " +
+                "\"http://127.0.0.1:8080\" or whatever is specified for the redirect URI " +
+                "option.",
         true,
     )
 
@@ -53,21 +66,28 @@ val spoofClientPatch = bytecodePatch(
 
         // endregion
 
-        // region Patch user agent.
+        // region Patch user agent and redirect URI.
 
-        // Take advantage of the fact that String.format() will ignore extraneous parameters.
         val stringReplacements = mapOf(
+            // Take advantage of the fact that String.format() will ignore extraneous parameters.
             "%s:%s:%s (by /u/%s)" to userAgent,
+            "http://rubenmayayo.com" to redirectUri
         )
 
-        buildUserAgentFingerprint.method.apply {
-            buildUserAgentFingerprint.stringMatches!!.forEach { match ->
-                val replacement = stringReplacements[match.string]
-                val register = getInstruction<OneRegisterInstruction>(match.index).registerA
+        val replaceStrings = fun(methodFingerprint: Fingerprint) : Unit {
+            methodFingerprint.method.apply {
+                methodFingerprint.stringMatches!!.forEach { match ->
+                    val replacement = stringReplacements[match.string]
+                    val register = getInstruction<OneRegisterInstruction>(match.index).registerA
 
-                replaceInstruction(match.index, "const-string v$register, \"$replacement\"")
+                    replaceInstruction(match.index, "const-string v$register, \"$replacement\"")
+                }
             }
         }
+
+        replaceStrings(buildUserAgentFingerprint)
+        replaceStrings(loginActivityOnCreateFingerprint)
+        replaceStrings(loginActivityAShouldOverrideUrlLoadingFingerprint)
 
         // endregion
     }

--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
@@ -5,61 +5,18 @@ import app.revanced.patcher.Match
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.revanced.patcher.patch.BytecodePatchBuilder
-import app.revanced.patcher.patch.Option
-import app.revanced.patcher.patch.bytecodePatch
-import app.revanced.patcher.patch.stringOption
+import app.revanced.patches.reddit.customclients.spoofClientPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
-@Suppress("unused")
-val spoofClientPatch = bytecodePatch(
-    name = "Spoof client",
-) {
+val spoofClientPatch = spoofClientPatch() { clientIdOption, redirectUriOption, userAgentOption ->
     compatibleWith("com.rubenmayayo.reddit")
-
-    val redirectUri by stringOption(
-        "redirect-uri",
-        "http://127.0.0.1:8080",
-        null,
-        "Redirect URI",
-        "The Reddit OAuth redirect URI. " +
-                "If you don't know what this means, don't change it. " +
-                "Make sure you update the \"Installed app\" you created at " +
-                "https://www.reddit.com/prefs/apps to have the same redirect URI " +
-                "as what you put here.",
-        true,
-    )
-
-    val clientId by stringOption(
-        "client-id",
-        null,
-        null,
-        "OAuth client ID",
-        "The Reddit OAuth client ID. " +
-                "You can get a client ID by creating an \"Installed app\" at " +
-                "https://www.reddit.com/prefs/apps. The redirect URI should be set to " +
-                "\"http://127.0.0.1:8080\" or whatever is specified for the redirect URI " +
-                "option.",
-        true,
-    )
-
-    val userAgent by stringOption(
-        "user-agent",
-        null,
-        null,
-        "User agent",
-        "The app's user agent. User agent should be in the format " +
-                "\"<platform>:<app id>:<version> (by /u/<username)\".",
-        true,
-    )
-
     execute {
         // region Patch client id.
 
         getClientIdFingerprint.method.addInstructions(
             0,
             """
-                 const-string v0, "$clientId"
+                 const-string v0, "$clientIdOption"
                  return-object v0
             """,
         )
@@ -70,8 +27,8 @@ val spoofClientPatch = bytecodePatch(
 
         val stringReplacements = mapOf(
             // Take advantage of the fact that String.format() will ignore extraneous parameters.
-            "%s:%s:%s (by /u/%s)" to userAgent,
-            "http://rubenmayayo.com" to redirectUri
+            "%s:%s:%s (by /u/%s)" to userAgentOption,
+            "http://rubenmayayo.com" to redirectUriOption
         )
 
         val replaceStrings = fun(methodFingerprint: Fingerprint) : Unit {

--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
@@ -2,11 +2,43 @@ package app.revanced.patches.reddit.customclients.boostforreddit.api
 
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patches.reddit.customclients.spoofClientPatch
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
-val spoofClientPatch = spoofClientPatch(redirectUri = "http://rubenmayayo.com") { clientIdOption ->
+import app.revanced.patcher.patch.BytecodePatchBuilder
+import app.revanced.patcher.patch.Option
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patcher.patch.stringOption
+
+@Suppress("unused")
+val spoofClientPatch = bytecodePatch(
+    name = "Spoof client",
+) {
     compatibleWith("com.rubenmayayo.reddit")
 
-    val clientId by clientIdOption
+    val redirectUri = "http://rubenmayayo.com"
+    val clientId by stringOption(
+        "client-id",
+        null,
+        null,
+        "OAuth client ID",
+        "The Reddit OAuth client ID. " +
+                "You can get your client ID from https://www.reddit.com/prefs/apps. " +
+                "The application type has to be \"Installed app\" " +
+                "and the redirect URI has to be set to \"$redirectUri\".",
+        true,
+    )
+
+    val userAgent by stringOption(
+        "user-agent",
+        null,
+        null,
+        "User agent",
+        "The app's user agent. User agent should be in the format " +
+                "\"<platform>:<app id>:<version> (by /u/<username)\".",
+        true,
+    )
 
     execute {
         // region Patch client id.
@@ -23,14 +55,19 @@ val spoofClientPatch = spoofClientPatch(redirectUri = "http://rubenmayayo.com") 
 
         // region Patch user agent.
 
-        // Use a random number as the platform in the user agent string.
-        val platformName = (0..100000).random()
-        val platformParameter = 0
-
-        buildUserAgentFingerprint.method.addInstructions(
-            0,
-            "const-string p$platformParameter, \"$platformName\"",
+        // Take advantage of the fact that String.format() will ignore extraneous parameters.
+        val stringReplacements = mapOf(
+            "%s:%s:%s (by /u/%s)" to userAgent,
         )
+
+        buildUserAgentFingerprint.method.apply {
+            buildUserAgentFingerprint.stringMatches!!.forEach { match ->
+                val replacement = stringReplacements[match.string]
+                val register = getInstruction<OneRegisterInstruction>(match.index).registerA
+
+                replaceInstruction(match.index, "const-string v$register, \"$replacement\"")
+            }
+        }
 
         // endregion
     }


### PR DESCRIPTION
Fixes #4549.

This patch adds two new options `user-agent` and `redirect-uri` that can be used to spoof the user agent and OAuth redirect URI for Boost for Reddit.

It takes a different approach from the earlier user agent patch that used the old ReVanced API by directly replacing the format string used to construct the user agent.

Other clients will likely eventually need a similar patch; however, I don't have the time to implement this for other clients. A new interface has been added that other clients can move to as needed.