### PR TITLE
feat(YouTube - Swipe controls): Add option to change volume swipe sensitivity

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -318,6 +318,7 @@ public class Settings extends BaseSettings {
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final IntegerSetting SWIPE_MAGNITUDE_THRESHOLD = new IntegerSetting("revanced_swipe_threshold", 30, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
+    public static final IntegerSetting SWIPE_VOLUME_MULTIPLIER = new IntegerSetting("revanced_swipe_volume_multiplier", 1, true, parent(SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_SHOW_CIRCULAR_OVERLAY = new BooleanSetting("revanced_swipe_show_circular_overlay", FALSE, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_OVERLAY_MINIMAL_STYLE = new BooleanSetting("revanced_swipe_overlay_minimal_style", FALSE, true,

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -318,7 +318,7 @@ public class Settings extends BaseSettings {
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final IntegerSetting SWIPE_MAGNITUDE_THRESHOLD = new IntegerSetting("revanced_swipe_threshold", 30, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
-    public static final IntegerSetting SWIPE_VOLUME_MULTIPLIER = new IntegerSetting("revanced_swipe_volume_multiplier", 1, true, parent(SWIPE_VOLUME));
+    public static final IntegerSetting SWIPE_VOLUME_SENSITIVITY = new IntegerSetting("revanced_swipe_volume_sensitivity", 1, true, parent(SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_SHOW_CIRCULAR_OVERLAY = new BooleanSetting("revanced_swipe_show_circular_overlay", FALSE, true,
             parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME));
     public static final BooleanSetting SWIPE_OVERLAY_MINIMAL_STYLE = new BooleanSetting("revanced_swipe_overlay_minimal_style", FALSE, true,

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -62,10 +62,21 @@ class SwipeControlsConfigurationProvider(
         get() = Settings.SWIPE_MAGNITUDE_THRESHOLD.get()
 
     /**
-     * how much volume will change by single swipe
+     * How much volume will change by single swipe.
+     * If it is set to 0, it will reset to the default value because 0 would disable swiping.
      * */
     val volumeSwipeSensitivity: Int
-        get() = Settings.SWIPE_VOLUME_SENSITIVITY.get()
+        get() {
+            val sensitivity = Settings.SWIPE_VOLUME_SENSITIVITY.get()
+
+            if (sensitivity < 1) {
+                Settings.SWIPE_VOLUME_SENSITIVITY.resetToDefault()
+
+                return Settings.SWIPE_VOLUME_SENSITIVITY.get()
+            }
+
+            return sensitivity
+        }
 //endregion
 
 //region overlay adjustments

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -60,6 +60,12 @@ class SwipeControlsConfigurationProvider(
      */
     val swipeMagnitudeThreshold: Int
         get() = Settings.SWIPE_MAGNITUDE_THRESHOLD.get()
+
+    /**
+     * how much volume will change by single swipe
+     * */
+    val volumeSwipeMultiplier: Int
+        get() = Settings.SWIPE_VOLUME_MULTIPLIER.get()
 //endregion
 
 //region overlay adjustments

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -64,8 +64,8 @@ class SwipeControlsConfigurationProvider(
     /**
      * how much volume will change by single swipe
      * */
-    val volumeSwipeMultiplier: Int
-        get() = Settings.SWIPE_VOLUME_MULTIPLIER.get()
+    val volumeSwipeSensitivity: Int
+        get() = Settings.SWIPE_VOLUME_SENSITIVITY.get()
 //endregion
 
 //region overlay adjustments

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -1,6 +1,5 @@
 package app.revanced.extension.youtube.swipecontrols
 
-import android.content.Context
 import android.graphics.Color
 import app.revanced.extension.shared.StringRef.str
 import app.revanced.extension.shared.Utils
@@ -9,12 +8,8 @@ import app.revanced.extension.youtube.shared.PlayerType
 
 /**
  * provider for configuration for volume and brightness swipe controls
- *
- * @param context the context to create in
  */
-class SwipeControlsConfigurationProvider(
-    private val context: Context,
-) {
+class SwipeControlsConfigurationProvider {
 //region swipe enable
     /**
      * should swipe controls be enabled? (global setting)

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
@@ -127,7 +127,7 @@ class SwipeControlsHostActivity : Activity() {
     private fun initialize() {
         // create controllers
         printDebug { "initializing swipe controls controllers" }
-        config = SwipeControlsConfigurationProvider(this)
+        config = SwipeControlsConfigurationProvider()
         keys = VolumeKeysController(this)
         audio = createAudioController()
         screen = createScreenController()

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/VolumeKeysController.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/VolumeKeysController.kt
@@ -41,7 +41,7 @@ class VolumeKeysController(
     private fun handleVolumeKeyEvent(event: KeyEvent, volumeUp: Boolean): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN) {
             controller.audio?.apply {
-                volume += controller.config.volumeSwipeMultiplier * if (volumeUp) 1 else -1
+                volume += controller.config.volumeSwipeSensitivity * if (volumeUp) 1 else -1
                 controller.overlay.onVolumeChanged(volume, maxVolume)
             }
         }

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/VolumeKeysController.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/VolumeKeysController.kt
@@ -41,7 +41,7 @@ class VolumeKeysController(
     private fun handleVolumeKeyEvent(event: KeyEvent, volumeUp: Boolean): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN) {
             controller.audio?.apply {
-                volume += if (volumeUp) 1 else -1
+                volume += controller.config.volumeSwipeMultiplier * if (volumeUp) 1 else -1
                 controller.overlay.onVolumeChanged(volume, maxVolume)
             }
         }

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -24,6 +24,7 @@ abstract class BaseGestureController(
         controller.overlay,
         10,
         1,
+        controller.config.volumeSwipeMultiplier,
     ) {
 
     /**

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -24,7 +24,7 @@ abstract class BaseGestureController(
         controller.overlay,
         10,
         1,
-        controller.config.volumeSwipeMultiplier,
+        controller.config.volumeSwipeSensitivity,
     ) {
 
     /**

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
@@ -41,7 +41,7 @@ interface VolumeAndBrightnessScroller {
  * @param overlayController overlay controller instance
  * @param volumeDistance unit distance for volume scrolling, in dp
  * @param brightnessDistance unit distance for brightness scrolling, in dp
- * @param volumeSwipeMultiplier how much volume will change by single swipe
+ * @param volumeSwipeSensitivity how much volume will change by single swipe
  */
 class VolumeAndBrightnessScrollerImpl(
     context: Context,
@@ -50,7 +50,7 @@ class VolumeAndBrightnessScrollerImpl(
     private val overlayController: SwipeControlsOverlay,
     volumeDistance: Int = 10,
     brightnessDistance: Int = 1,
-    private val volumeSwipeMultiplier: Int,
+    private val volumeSwipeSensitivity: Int,
 ) : VolumeAndBrightnessScroller {
 
     // region volume
@@ -62,7 +62,7 @@ class VolumeAndBrightnessScrollerImpl(
             ),
         ) { _, _, direction ->
             volumeController?.run {
-                volume += direction * volumeSwipeMultiplier
+                volume += direction * volumeSwipeSensitivity
                 overlayController.onVolumeChanged(volume, maxVolume)
             }
         }

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
@@ -41,6 +41,7 @@ interface VolumeAndBrightnessScroller {
  * @param overlayController overlay controller instance
  * @param volumeDistance unit distance for volume scrolling, in dp
  * @param brightnessDistance unit distance for brightness scrolling, in dp
+ * @param volumeSwipeMultiplier how much volume will change by single swipe
  */
 class VolumeAndBrightnessScrollerImpl(
     context: Context,
@@ -49,6 +50,7 @@ class VolumeAndBrightnessScrollerImpl(
     private val overlayController: SwipeControlsOverlay,
     volumeDistance: Int = 10,
     brightnessDistance: Int = 1,
+    private val volumeSwipeMultiplier: Int,
 ) : VolumeAndBrightnessScroller {
 
     // region volume
@@ -60,7 +62,7 @@ class VolumeAndBrightnessScrollerImpl(
             ),
         ) { _, _, direction ->
             volumeController?.run {
-                volume += direction
+                volume += direction * volumeSwipeMultiplier
                 overlayController.onVolumeChanged(volume, maxVolume)
             }
         }

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/views/SwipeControlsOverlayLayout.kt
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/swipecontrols/views/SwipeControlsOverlayLayout.kt
@@ -25,7 +25,7 @@ class SwipeControlsOverlayLayout(
     private val config: SwipeControlsConfigurationProvider,
 ) : RelativeLayout(context), SwipeControlsOverlay {
 
-    constructor(context: Context) : this(context, SwipeControlsConfigurationProvider(context))
+    constructor(context: Context) : this(context, SwipeControlsConfigurationProvider())
 
     // Drawable icons for brightness and volume
     private val autoBrightnessIcon: Drawable = getDrawable("revanced_ic_sc_brightness_auto")

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -47,7 +47,7 @@ private val swipeControlsResourcePatch = resourcePatch {
             TextPreference("revanced_swipe_overlay_background_opacity", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_overlay_timeout", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_threshold", inputType = InputType.NUMBER),
-            TextPreference("revanced_swipe_volume_multiplier", inputType = InputType.NUMBER),
+            TextPreference("revanced_swipe_volume_sensitivity", inputType = InputType.NUMBER),
         )
 
         copyResources(

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -47,6 +47,7 @@ private val swipeControlsResourcePatch = resourcePatch {
             TextPreference("revanced_swipe_overlay_background_opacity", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_overlay_timeout", inputType = InputType.NUMBER),
             TextPreference("revanced_swipe_threshold", inputType = InputType.NUMBER),
+            TextPreference("revanced_swipe_volume_multiplier", inputType = InputType.NUMBER),
         )
 
         copyResources(

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -515,7 +515,7 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
             <string name="revanced_swipe_threshold_title">Swipe magnitude threshold</string>
             <string name="revanced_swipe_threshold_summary">The amount of threshold for swipe to occur</string>
             <string name="revanced_swipe_volume_sensitivity_title">Volume swipe sensitivity</string>
-            <string name="revanced_swipe_volume_sensitivity_summary">Adjust volume change per swipe</string>
+            <string name="revanced_swipe_volume_sensitivity_summary">How much the volume changes per swipe</string>
             <string name="revanced_swipe_show_circular_overlay_title">Show circular overlay</string>
             <string name="revanced_swipe_show_circular_overlay_summary_on">Circular overlay is shown</string>
             <string name="revanced_swipe_show_circular_overlay_summary_off">Horizontal overlay is shown</string>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -514,6 +514,8 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
             <string name="revanced_swipe_overlay_background_opacity_invalid_toast">Swipe opacity must be between 0-100</string>
             <string name="revanced_swipe_threshold_title">Swipe magnitude threshold</string>
             <string name="revanced_swipe_threshold_summary">The amount of threshold for swipe to occur</string>
+            <string name="revanced_swipe_volume_multiplier_title">Volume swipe multiplier</string>
+            <string name="revanced_swipe_volume_multiplier_summary">Adjust volume change per swipe</string>
             <string name="revanced_swipe_show_circular_overlay_title">Show circular overlay</string>
             <string name="revanced_swipe_show_circular_overlay_summary_on">Circular overlay is shown</string>
             <string name="revanced_swipe_show_circular_overlay_summary_off">Horizontal overlay is shown</string>

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -514,8 +514,8 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
             <string name="revanced_swipe_overlay_background_opacity_invalid_toast">Swipe opacity must be between 0-100</string>
             <string name="revanced_swipe_threshold_title">Swipe magnitude threshold</string>
             <string name="revanced_swipe_threshold_summary">The amount of threshold for swipe to occur</string>
-            <string name="revanced_swipe_volume_multiplier_title">Volume swipe multiplier</string>
-            <string name="revanced_swipe_volume_multiplier_summary">Adjust volume change per swipe</string>
+            <string name="revanced_swipe_volume_sensitivity_title">Volume swipe sensitivity</string>
+            <string name="revanced_swipe_volume_sensitivity_summary">Adjust volume change per swipe</string>
             <string name="revanced_swipe_show_circular_overlay_title">Show circular overlay</string>
             <string name="revanced_swipe_show_circular_overlay_summary_on">Circular overlay is shown</string>
             <string name="revanced_swipe_show_circular_overlay_summary_off">Horizontal overlay is shown</string>


### PR DESCRIPTION
It's super annoying to scroll through 160 volume levels, so I've added an option to customize how much volume a single swipe changes.

May fix #1646, #3094, #1108