### PR TITLE
feat(Photomath): Support latest version

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/photomath/detection/deviceid/SpoofDeviceIdPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/photomath/detection/deviceid/SpoofDeviceIdPatch.kt
@@ -12,7 +12,7 @@ val getDeviceIdPatch = bytecodePatch(
 ) {
     dependsOn(signatureDetectionPatch)
 
-    compatibleWith("com.microblink.photomath"("8.37.0"))
+    compatibleWith("com.microblink.photomath")
 
     execute {
         getDeviceIdFingerprint.method.replaceInstructions(

--- a/patches/src/main/kotlin/app/revanced/patches/photomath/detection/signature/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/photomath/detection/signature/Fingerprints.kt
@@ -14,5 +14,5 @@ internal val checkSignatureFingerprint = fingerprint {
         Opcode.INVOKE_STATIC,
         Opcode.MOVE_RESULT,
     )
-    strings("signatures")
+    strings("SHA")
 }

--- a/patches/src/main/kotlin/app/revanced/patches/photomath/misc/annoyances/HideUpdatePopupPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/photomath/misc/annoyances/HideUpdatePopupPatch.kt
@@ -11,7 +11,7 @@ val hideUpdatePopupPatch = bytecodePatch(
 ) {
     dependsOn(signatureDetectionPatch)
 
-    compatibleWith("com.microblink.photomath"("8.32.0"))
+    compatibleWith("com.microblink.photomath")
 
     execute {
         hideUpdatePopupFingerprint.method.addInstructions(

--- a/patches/src/main/kotlin/app/revanced/patches/photomath/misc/unlock/plus/UnlockPlusPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/photomath/misc/unlock/plus/UnlockPlusPatch.kt
@@ -11,7 +11,7 @@ val unlockPlusPatch = bytecodePatch(
 ) {
     dependsOn(signatureDetectionPatch, enableBookpointPatch)
 
-    compatibleWith("com.microblink.photomath"("8.37.0"))
+    compatibleWith("com.microblink.photomath")
 
     execute {
         isPlusUnlockedFingerprint.method.addInstructions(


### PR DESCRIPTION
Tested on Photomath 8.43.0

I removed the version constraints since all patches succeed, but I'm not sure about `Hide update popup` since it was constrained to an older version than the rest of the patches. I can't test it because there wouldn't be an update to trigger such a popup.