### PR TITLE
feat(Messenger): Add `Remove Meta AI tab`

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/messenger/navbar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/messenger/navbar/Fingerprints.kt
@@ -1,0 +1,16 @@
+package app.revanced.patches.messenger.navbar
+
+import app.revanced.patcher.fingerprint
+import com.android.tools.smali.dexlib2.Opcode
+
+internal val createTabConfigurationFingerprint = fingerprint {
+    strings("MessengerTabConfigurationCreator.createTabConfiguration")
+    opcodes(
+        Opcode.INVOKE_DIRECT,
+        Opcode.MOVE_RESULT,
+        Opcode.IF_EQZ,
+        Opcode.INVOKE_DIRECT,
+        Opcode.MOVE_RESULT,
+        Opcode.IF_EQZ,
+    )
+}

--- a/patches/src/main/kotlin/app/revanced/patches/messenger/navbar/RemoveMetaAITabPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/messenger/navbar/RemoveMetaAITabPatch.kt
@@ -1,0 +1,19 @@
+package app.revanced.patches.messenger.navbar
+
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+
+@Suppress("unused")
+val removeMetaAITabPatch = bytecodePatch(
+    name = "Remove Meta AI tab",
+    description = "Removes the 'Meta AI' tab from the navbar.",
+) {
+    compatibleWith("com.facebook.orca")
+
+    execute {
+        createTabConfigurationFingerprint.method.replaceInstruction(
+            createTabConfigurationFingerprint.patternMatch!!.startIndex + 1,
+            "const/4 v2, 0x0"
+        )
+    }
+}


### PR DESCRIPTION
Simple patch to remove the annoying AI slop `Meta AI` tab from the bottom navbar.