### PR TITLE
fix(Spotify - Unlock Spotify Premium): Remove premium restriction on Spotify Connect 

### DIFF
--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
@@ -80,14 +80,14 @@ public final class UnlockPremiumPatch {
             new OverrideAttribute("streaming-rules", ""),
             // Enables premium UI in settings and removes the premium button in the nav-bar.
             new OverrideAttribute("nft-disabled", "1"),
+            // Removes Spotify Connect as a premium only feature.
+            new OverrideAttribute("type", "premium"),
             // Enable Spotify Car Thing hardware device.
             // Device is discontinued and no longer works with the latest releases,
             // but it might still work with older app targets.
             new OverrideAttribute("can_use_superbird", TRUE, false),
             // Removes the premium button in the nav-bar for tablet users.
-            new OverrideAttribute("tablet-free", FALSE, false),
-            // Removes Spotify Connect as a premium only feature.
-            new OverrideAttribute("type", "premium")
+            new OverrideAttribute("tablet-free", FALSE, false)
     );
 
     private static final List<Integer> REMOVED_HOME_SECTIONS = List.of(

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
@@ -80,7 +80,8 @@ public final class UnlockPremiumPatch {
             new OverrideAttribute("streaming-rules", ""),
             // Enables premium UI in settings and removes the premium button in the nav-bar.
             new OverrideAttribute("nft-disabled", "1"),
-            // Removes Spotify Connect as a premium only feature.
+            // Enable Spotify Connect and disable other premium related UI, like buying premium.
+            // It also removes the download button.
             new OverrideAttribute("type", "premium"),
             // Enable Spotify Car Thing hardware device.
             // Device is discontinued and no longer works with the latest releases,

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
@@ -85,7 +85,9 @@ public final class UnlockPremiumPatch {
             // but it might still work with older app targets.
             new OverrideAttribute("can_use_superbird", TRUE, false),
             // Removes the premium button in the nav-bar for tablet users.
-            new OverrideAttribute("tablet-free", FALSE, false)
+            new OverrideAttribute("tablet-free", FALSE, false),
+            // Removes Spotify Connect as a premium only feature.
+            new OverrideAttribute("type", "premium")
     );
 
     private static final List<Integer> REMOVED_HOME_SECTIONS = List.of(


### PR DESCRIPTION
For some people, including myself, Spotify Connect is restricted behind Premium subscription. This PR simply removes this restriction. This would also close https://github.com/ReVanced/revanced-patches/issues/4675 (although is already closed since no other people reported it).

![Screenshot_2025-04-13-20-42-18-12_0438eb925998df20b3482ec25499d226 (1)](https://github.com/user-attachments/assets/4f89c67a-b899-4468-9c2e-8b67bd7d8f5d)
