### PR TITLE
fix(Duolingo): Update `DisableAdsPatch` fingerprint for refactored package name

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/duolingo/ad/DisableAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/duolingo/ad/DisableAdsPatch.kt
@@ -19,8 +19,15 @@ val disableAdsPatch = bytecodePatch(
         // SharedPreferences has a debug boolean value with key "disable_ads", which maps to "DebugCategory.DISABLE_ADS".
         //
         // MonetizationDebugSettings seems to be the most general setting to work fine.
-        initializeMonetizationDebugSettingsFingerprint.method.apply {
-            val insertIndex = initializeMonetizationDebugSettingsFingerprint.patternMatch!!.startIndex
+
+        // FamilyQuestOverride package has been refactored, so check both fully-qualified names.
+        val oldFingerprint = buildInitMonetizationFingerprint("Lcom/duolingo/debug/FamilyQuestOverride;")
+        val newFingerprint =
+            buildInitMonetizationFingerprint("Lcom/duolingo/data/debug/monetization/FamilyQuestOverride;")
+        val foundFingerprint = if (newFingerprint.methodOrNull != null) newFingerprint else oldFingerprint
+
+        foundFingerprint.method.apply {
+            val insertIndex = foundFingerprint.patternMatch!!.startIndex
             val register = getInstruction<TwoRegisterInstruction>(insertIndex).registerA
 
             addInstructions(

--- a/patches/src/main/kotlin/app/revanced/patches/duolingo/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/duolingo/ad/Fingerprints.kt
@@ -4,7 +4,7 @@ import app.revanced.patcher.fingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
-internal val initializeMonetizationDebugSettingsFingerprint = fingerprint {
+internal fun buildInitMonetizationFingerprint(lastParam: String) = fingerprint {
     accessFlags(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR)
     returns("V")
     parameters(
@@ -12,7 +12,7 @@ internal val initializeMonetizationDebugSettingsFingerprint = fingerprint {
         "Z", // useDebugBilling
         "Z", // showManageSubscriptions
         "Z", // alwaysShowSuperAds
-        "Lcom/duolingo/debug/FamilyQuestOverride;",
+        lastParam,
     )
     opcodes(Opcode.IPUT_BOOLEAN)
 }


### PR DESCRIPTION
Fixes #4728 

Looks like Duolingo just refactored some of the package names, causing the fingerprint to fail. Checking for both variants to support new and old versions of the app.