### PR TITLE
fix(Spotify): Fix login by replacing `Spoof signature` patch with new `Spoof package info` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -842,6 +842,10 @@ public final class app/revanced/patches/spotify/misc/extension/ExtensionPatchKt 
 	public static final fun getSharedExtensionPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatchKt {
+	public static final fun getSpoofPackageInfoPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/spotify/misc/fix/SpoofSignaturePatchKt {
 	public static final fun getSpoofSignaturePatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
@@ -2,4 +2,4 @@ package app.revanced.patches.spotify.misc.fix
 
 import app.revanced.patcher.fingerprint
 
-internal val getAppSignatureFingerprint = fingerprint { strings("Failed to get the application signatures") }
+internal val getPackageInfoFingerprint = fingerprint { strings("Failed to get the application signatures") }

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
@@ -3,5 +3,15 @@ package app.revanced.patches.spotify.misc.fix
 import app.revanced.patcher.fingerprint
 
 internal val getPackageInfoFingerprint = fingerprint {
-    strings("Failed to get the application signatures")
+    strings(
+        "Failed to get the application signatures",
+        "Failed to get installer package"
+    )
 }
+
+internal val getPackageInfoLegacyFingerprint = fingerprint {
+    strings(
+        "Failed to get the application signatures"
+    )
+}
+

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
@@ -2,4 +2,9 @@ package app.revanced.patches.spotify.misc.fix
 
 import app.revanced.patcher.fingerprint
 
-internal val getPackageInfoFingerprint = fingerprint { strings("Failed to get the application signatures") }
+internal val getPackageInfoFingerprint = fingerprint {
+    strings(
+        "Failed to get the application signatures",
+        "Failed to get installer package"
+    )
+}

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/Fingerprints.kt
@@ -3,8 +3,5 @@ package app.revanced.patches.spotify.misc.fix
 import app.revanced.patcher.fingerprint
 
 internal val getPackageInfoFingerprint = fingerprint {
-    strings(
-        "Failed to get the application signatures",
-        "Failed to get installer package"
-    )
+    strings("Failed to get the application signatures")
 }

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
@@ -1,0 +1,52 @@
+package app.revanced.patches.spotify.misc.fix
+
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.instructions
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.util.addInstructionsAtControlFlowLabel
+import app.revanced.util.indexOfFirstInstructionReversedOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+@Suppress("unused")
+val spoofPackageInfoPatch = bytecodePatch(
+    name = "Spoof package info",
+    description = "Spoofs the package info of the app to fix various functions of the app.",
+) {
+    compatibleWith("com.spotify.music")
+
+    execute {
+        getPackageInfoFingerprint.method.apply {
+            // region Spoof signature.
+
+            val failedToGetSignaturesStringMatch = getPackageInfoFingerprint.stringMatches!!.first()
+
+            val concatSignaturesIndex = indexOfFirstInstructionReversedOrThrow(
+                failedToGetSignaturesStringMatch.index,
+                Opcode.MOVE_RESULT_OBJECT,
+            )
+
+            val signatureRegister = getInstruction<OneRegisterInstruction>(concatSignaturesIndex).registerA
+            val expectedSignature = "d6a6dced4a85f24204bf9505ccc1fce114cadb32"
+
+            replaceInstruction(concatSignaturesIndex, "const-string v$signatureRegister, \"$expectedSignature\"")
+
+            // endregion
+
+            // region Spoof installer name.
+
+            val returnInstallerNameIndex = instructions.size - 3
+
+            val installerNameRegister = getInstruction<OneRegisterInstruction>(returnInstallerNameIndex).registerA
+            val expectedInstallerName = "com.android.vending"
+
+            addInstructionsAtControlFlowLabel(
+                returnInstallerNameIndex,
+                "const-string v$installerNameRegister, \"$expectedInstallerName\"",
+            )
+
+            // endregion
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
@@ -18,14 +18,14 @@ val spoofPackageInfoPatch = bytecodePatch(
     compatibleWith("com.spotify.music")
 
     execute {
-        val packageInfoFingerprint = if (IS_SPOTIFY_LEGACY_APP_TARGET) {
+        val getPackageInfoFingerprint = if (IS_SPOTIFY_LEGACY_APP_TARGET) {
             getPackageInfoLegacyFingerprint
         } else {
             getPackageInfoFingerprint
         }
 
-        packageInfoFingerprint.method.apply {
-            val stringMatches = packageInfoFingerprint.stringMatches!!
+        getPackageInfoFingerprint.method.apply {
+            val stringMatches = getPackageInfoFingerprint.stringMatches!!
 
             // region Spoof signature.
 
@@ -46,7 +46,7 @@ val spoofPackageInfoPatch = bytecodePatch(
             // region Spoof installer name.
 
             if (IS_SPOTIFY_LEGACY_APP_TARGET) {
-                // Package installer name does not appear to be used with the legacy app target.
+                // Installer name is not used in the legacy app target.
                 return@execute
             }
 

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
@@ -36,7 +36,10 @@ val spoofPackageInfoPatch = bytecodePatch(
 
             // region Spoof installer name.
 
-            val returnInstallerNameIndex = instructions.size - 3
+            val returnInstallerNameIndex = indexOfFirstInstructionReversedOrThrow(
+                instructions.lastIndex,
+                Opcode.RETURN_OBJECT
+            )
 
             val installerNameRegister = getInstruction<OneRegisterInstruction>(returnInstallerNameIndex).registerA
             val expectedInstallerName = "com.android.vending"

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
@@ -5,6 +5,7 @@ import app.revanced.patcher.extensions.InstructionExtensions.instructions
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.util.addInstructionsAtControlFlowLabel
+import app.revanced.util.indexOfFirstInstructionOrThrow
 import app.revanced.util.indexOfFirstInstructionReversedOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -20,10 +21,10 @@ val spoofPackageInfoPatch = bytecodePatch(
         getPackageInfoFingerprint.method.apply {
             // region Spoof signature.
 
-            val failedToGetSignaturesStringMatch = getPackageInfoFingerprint.stringMatches!!.first()
+            val failedToGetSignaturesStringIndex = getPackageInfoFingerprint.stringMatches!!.first().index
 
             val concatSignaturesIndex = indexOfFirstInstructionReversedOrThrow(
-                failedToGetSignaturesStringMatch.index,
+                failedToGetSignaturesStringIndex,
                 Opcode.MOVE_RESULT_OBJECT,
             )
 
@@ -36,8 +37,10 @@ val spoofPackageInfoPatch = bytecodePatch(
 
             // region Spoof installer name.
 
-            val returnInstallerNameIndex = indexOfFirstInstructionReversedOrThrow(
-                instructions.lastIndex,
+            val failedToGetInstallerPackageStringIndex = getPackageInfoFingerprint.stringMatches!!.last().index
+
+            val returnInstallerNameIndex = indexOfFirstInstructionOrThrow(
+                failedToGetInstallerPackageStringIndex,
                 Opcode.RETURN_OBJECT
             )
 

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofPackageInfoPatch.kt
@@ -3,9 +3,9 @@ package app.revanced.patches.spotify.misc.fix
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.instructions
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.fingerprint
 import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.util.addInstructionsAtControlFlowLabel
-import app.revanced.util.indexOfFirstInstructionOrThrow
 import app.revanced.util.indexOfFirstInstructionReversedOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -37,10 +37,11 @@ val spoofPackageInfoPatch = bytecodePatch(
 
             // region Spoof installer name.
 
-            val failedToGetInstallerPackageStringIndex = getPackageInfoFingerprint.stringMatches!!.last().index
+            // Old versions of Spotify do not check the installer name.
+            fingerprint { strings("Failed to get installer package") }.matchOrNull(this) ?: return@execute
 
-            val returnInstallerNameIndex = indexOfFirstInstructionOrThrow(
-                failedToGetInstallerPackageStringIndex,
+            val returnInstallerNameIndex = indexOfFirstInstructionReversedOrThrow(
+                instructions.size,
                 Opcode.RETURN_OBJECT
             )
 

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofSignaturePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/fix/SpoofSignaturePatch.kt
@@ -1,33 +1,13 @@
 package app.revanced.patches.spotify.misc.fix
 
-import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
-import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.revanced.patcher.patch.bytecodePatch
-import app.revanced.util.indexOfFirstInstructionReversedOrThrow
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
+@Deprecated("Superseded by spoofPackageInfoPatch", ReplaceWith("spoofPackageInfoPatch"))
 @Suppress("unused")
 val spoofSignaturePatch = bytecodePatch(
-    name = "Spoof signature",
-    description = "Spoofs the signature of the app to fix various functions of the app.",
+    description = "Spoofs the signature of the app fix various functions of the app.",
 ) {
     compatibleWith("com.spotify.music")
 
-    execute {
-        getAppSignatureFingerprint.method.apply {
-            val failedToGetSignaturesStringMatch = getAppSignatureFingerprint.stringMatches!!.first()
-
-            val concatSignaturesIndex = indexOfFirstInstructionReversedOrThrow(
-                failedToGetSignaturesStringMatch.index,
-                Opcode.MOVE_RESULT_OBJECT,
-            )
-
-            val register = getInstruction<OneRegisterInstruction>(concatSignaturesIndex).registerA
-
-            val expectedSignature = "d6a6dced4a85f24204bf9505ccc1fce114cadb32"
-
-            replaceInstruction(concatSignaturesIndex, "const-string v$register, \"$expectedSignature\"")
-        }
-    }
+    dependsOn(spoofPackageInfoPatch)
 }


### PR DESCRIPTION
Spoofing the installer's name may or may not work. Currently testing. So far pretty much everyone reports it's working.