### PR TITLE
feat(X / Twitter): Support version `10.86.0-release.0`

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
@@ -12,7 +12,7 @@ val dynamicColorPatch = resourcePatch(
 ) {
     compatibleWith(
         "com.twitter.android"(
-            "10.84.0-release.0",
+            "10.86.0-release.0",
             "10.60.0-release.0",
             "10.48.0-release.0"
         )

--- a/patches/src/main/kotlin/app/revanced/patches/twitter/misc/hook/HookPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitter/misc/hook/HookPatch.kt
@@ -13,8 +13,8 @@ fun hookPatch(
 
     compatibleWith(
         "com.twitter.android"(
-            // 10.85+ uses Pairip and requires additional changes to work.
-            "10.84.0-release.0",
+            // Only v10.85 uses Pairip and requires additional changes to work.
+            "10.86.0-release.0",
             // Confirmed to not show reply ads. Slightly newer versions may also work.
             "10.60.0-release.0",
             "10.48.0-release.0"

--- a/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/ChangeLinkSharingDomainPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/ChangeLinkSharingDomainPatch.kt
@@ -39,7 +39,7 @@ val changeLinkSharingDomainPatch = bytecodePatch(
 
     compatibleWith(
         "com.twitter.android"(
-            "10.84.0-release.0",
+            "10.86.0-release.0",
             "10.60.0-release.0",
             "10.48.0-release.0"
         )

--- a/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/SanitizeSharingLinksPatch.kt
@@ -10,7 +10,7 @@ val sanitizeSharingLinksPatch = bytecodePatch(
 ) {
     compatibleWith(
         "com.twitter.android"(
-            "10.84.0-release.0",
+            "10.86.0-release.0",
             "10.60.0-release.0",
             "10.48.0-release.0"
         )


### PR DESCRIPTION
Devs of X/Twitter removed pairip in 10.85.
10.87 or up has issue https://github.com/ReVanced/revanced-patches/issues/4719.
So, 10.86 is last known good version.