### PR TITLE
chore(ryd): improved clarity on naming for estimated likes

### DIFF
--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -895,8 +895,8 @@ Limitation: Dislikes may not appear in incognito mode"</string>
             <string name="revanced_ryd_compact_layout_summary_on">Like button styled for minimum width</string>
             <string name="revanced_ryd_compact_layout_summary_off">Like button styled for best appearance</string>
             <string name="revanced_ryd_estimated_like_title">Show estimated likes</string>
-            <string name="revanced_ryd_estimated_like_summary_on">Estimated likes are shown</string>
-            <string name="revanced_ryd_estimated_like_summary_off">Estimated likes are hidden</string>
+            <string name="revanced_ryd_estimated_like_summary_on">Display estimated likes for videos with disabled like counts</string>
+            <string name="revanced_ryd_estimated_like_summary_off">Estimated like counts won’t be shown</string>
             <string name="revanced_ryd_toast_on_connection_error_title">Show a toast if API is not available</string>
             <string name="revanced_ryd_toast_on_connection_error_summary_on">Toast is shown if Return YouTube Dislike is not available</string>
             <string name="revanced_ryd_toast_on_connection_error_summary_off">Toast is not shown if Return YouTube Dislike is not available</string>


### PR DESCRIPTION
Currently, the naming for the "Estimated likes" feature from the "Return Youtube Dislikes" patch can be quite confusing to end users.

I've updated english translations to clarify how the feature works, as right now it might be hard to understand without looking at the source.