### PR TITLE
feat(Prime Video): Initial commit of Skip Ads patch

### DIFF
--- a/extensions/primevideo/build.gradle.kts
+++ b/extensions/primevideo/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    compileOnly(project(":extensions:primevideo:stub"))
+}

--- a/extensions/primevideo/src/main/AndroidManifest.xml
+++ b/extensions/primevideo/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest/>

--- a/extensions/primevideo/src/main/java/app/revanced/extension/primevideo/ads/SkipAdsPatch.java
+++ b/extensions/primevideo/src/main/java/app/revanced/extension/primevideo/ads/SkipAdsPatch.java
@@ -1,0 +1,25 @@
+package app.revanced.extension.primevideo.ads;
+
+import com.amazon.avod.fsm.SimpleTrigger;
+import com.amazon.avod.media.ads.AdBreak;
+import com.amazon.avod.media.ads.internal.state.AdBreakTrigger;
+import com.amazon.avod.media.ads.internal.state.AdEnabledPlayerTriggerType;
+import com.amazon.avod.media.playback.VideoPlayer;
+import com.amazon.avod.media.ads.internal.state.ServerInsertedAdBreakState;
+
+@SuppressWarnings("unused")
+public final class SkipAdsPatch {
+    public static void ServerInsertedAdBreakState_enter(ServerInsertedAdBreakState state, AdBreakTrigger trigger, VideoPlayer player) {
+        AdBreak adBreak = trigger.getBreak();
+
+        if (trigger.getSeekStartPosition() != null)
+            // if scrubbing over ad, seek straight to it
+            player.seekTo(trigger.getSeekTarget().getTotalMilliseconds());
+        else
+            // if naturally entering ad, seek to end of ad break
+            player.seekTo(player.getCurrentPosition() + adBreak.getDurationExcludingAux().getTotalMilliseconds());
+
+        // send "end of ads" trigger to state machine so everything doesn't get whacky
+        state.doTrigger(new SimpleTrigger(AdEnabledPlayerTriggerType.NO_MORE_ADS_SKIP_TRANSITION));
+    }
+}

--- a/extensions/primevideo/stub/build.gradle.kts
+++ b/extensions/primevideo/stub/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id(libs.plugins.android.library.get().pluginId)
+}
+
+android {
+    namespace = "app.revanced.extension"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/extensions/primevideo/stub/src/main/AndroidManifest.xml
+++ b/extensions/primevideo/stub/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest/>

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/SimpleTrigger.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/SimpleTrigger.java
@@ -1,0 +1,6 @@
+package com.amazon.avod.fsm;
+
+public final class SimpleTrigger<T> implements Trigger<T> {
+    public SimpleTrigger(T triggerType) {
+    }
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/StateBase.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/StateBase.java
@@ -1,0 +1,7 @@
+package com.amazon.avod.fsm;
+
+public abstract class StateBase<S, T> {
+    // originally protected access
+    public void doTrigger(Trigger<T> trigger) {
+    }
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/Trigger.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/fsm/Trigger.java
@@ -1,0 +1,4 @@
+package com.amazon.avod.fsm;
+
+public interface Trigger<T> {
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/TimeSpan.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/TimeSpan.java
@@ -1,0 +1,7 @@
+package com.amazon.avod.media;
+
+public final class TimeSpan {
+    public long getTotalMilliseconds() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/AdBreak.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/AdBreak.java
@@ -1,0 +1,7 @@
+package com.amazon.avod.media.ads;
+
+import com.amazon.avod.media.TimeSpan;
+
+public interface AdBreak {
+    TimeSpan getDurationExcludingAux();
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdBreakState.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdBreakState.java
@@ -1,0 +1,4 @@
+package com.amazon.avod.media.ads.internal.state;
+
+public abstract class AdBreakState extends AdEnabledPlaybackState {
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdBreakTrigger.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdBreakTrigger.java
@@ -1,0 +1,18 @@
+package com.amazon.avod.media.ads.internal.state;
+
+import com.amazon.avod.media.ads.AdBreak;
+import com.amazon.avod.media.TimeSpan;
+
+public class AdBreakTrigger {
+    public AdBreak getBreak() {
+        throw new UnsupportedOperationException();
+    }
+
+    public TimeSpan getSeekTarget() {
+        throw new UnsupportedOperationException();
+    }
+
+    public TimeSpan getSeekStartPosition() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdEnabledPlaybackState.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdEnabledPlaybackState.java
@@ -1,0 +1,8 @@
+package com.amazon.avod.media.ads.internal.state;
+
+import com.amazon.avod.fsm.StateBase;
+import com.amazon.avod.media.playback.state.PlayerStateType;
+import com.amazon.avod.media.playback.state.trigger.PlayerTriggerType;
+
+public class AdEnabledPlaybackState extends StateBase<PlayerStateType, PlayerTriggerType> {
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdEnabledPlayerTriggerType.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/AdEnabledPlayerTriggerType.java
@@ -1,0 +1,5 @@
+package com.amazon.avod.media.ads.internal.state;
+
+public enum AdEnabledPlayerTriggerType {
+    NO_MORE_ADS_SKIP_TRANSITION
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/ServerInsertedAdBreakState.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/ads/internal/state/ServerInsertedAdBreakState.java
@@ -1,0 +1,4 @@
+package com.amazon.avod.media.ads.internal.state;
+
+public class ServerInsertedAdBreakState extends AdBreakState {
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/VideoPlayer.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/VideoPlayer.java
@@ -1,0 +1,7 @@
+package com.amazon.avod.media.playback;
+
+public interface VideoPlayer {
+    long getCurrentPosition();
+
+    void seekTo(long positionMs);
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/state/PlayerStateType.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/state/PlayerStateType.java
@@ -1,0 +1,4 @@
+package com.amazon.avod.media.playback.state;
+
+public interface PlayerStateType {
+}

--- a/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/state/trigger/PlayerTriggerType.java
+++ b/extensions/primevideo/stub/src/main/java/com/amazon/avod/media/playback/state/trigger/PlayerTriggerType.java
@@ -1,0 +1,4 @@
+package com.amazon.avod.media.playback.state.trigger;
+
+public interface PlayerTriggerType {
+}

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -412,6 +412,10 @@ public final class app/revanced/patches/pixiv/ads/HideAdsPatchKt {
 	public static final fun getHideAdsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/primevideo/ads/SkipAdsPatchKt {
+	public static final fun getSkipAdsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/protonmail/signature/RemoveSentFromSignaturePatchKt {
 	public static final fun getRemoveSentFromSignaturePatch ()Lapp/revanced/patcher/patch/ResourcePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/primevideo/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/primevideo/ads/Fingerprints.kt
@@ -1,0 +1,34 @@
+package app.revanced.patches.primevideo.ads
+
+import app.revanced.patcher.fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal val enterServerInsertedAdBreakStateFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC)
+    parameters("Lcom/amazon/avod/fsm/Trigger;")
+    returns("V")
+    opcodes(
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.CONST_4,
+        Opcode.CONST_4
+    )
+    custom { method, classDef ->
+        classDef.type == "Lcom/amazon/avod/media/ads/internal/state/ServerInsertedAdBreakState;" &&
+                method.name == "enter"
+    }
+}
+
+internal val doTriggerFingerprint = fingerprint {
+    accessFlags(AccessFlags.PROTECTED)
+    returns("V")
+    opcodes(
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.RETURN_VOID
+    )
+    custom { method, classDef ->
+        classDef.type == "Lcom/amazon/avod/fsm/StateBase;" && method.name == "doTrigger"
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/primevideo/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/primevideo/ads/SkipAdsPatch.kt
@@ -1,0 +1,45 @@
+package app.revanced.patches.primevideo.ads
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patches.shared.misc.extension.sharedExtensionPatch
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+@Suppress("unused")
+val skipAdsPatch = bytecodePatch(
+    name = "Skip ads",
+    description = "Automatically skip over pre-baked ads in video streams.",
+) {
+    compatibleWith("com.amazon.avod.thirdpartyclient")
+
+    dependsOn(sharedExtensionPatch("primevideo"))
+
+    // We're going to skip all the logic in ServerInsertedAdBreakState.enter(), which plays all the ad clips in this
+    // ad break. Instead, we'll force the video player to seek over the entire break and reset the state machine.
+    execute {
+        // Force doTrigger() access to public so we can call it from our extension
+        doTriggerFingerprint.method.accessFlags = AccessFlags.PUBLIC.value;
+
+        val getPlayerIndex = enterServerInsertedAdBreakStateFingerprint.patternMatch!!.startIndex
+        enterServerInsertedAdBreakStateFingerprint.method.apply {
+            // Get register that stores VideoPlayer:
+            //  invoke-virtual ->getPrimaryPlayer()
+            //  move-result-object {vx}
+            val playerRegister = getInstruction<OneRegisterInstruction>(getPlayerIndex + 1).registerA
+
+            // Reuse the params from the original method
+            //  p0 = ServerInsertedAdBreakState
+            //  p1 = AdBreakTrigger
+            addInstructions(
+                getPlayerIndex + 2,
+                """
+                    invoke-static {p0, p1, v${playerRegister}}, Lapp/revanced/extension/primevideo/ads/SkipAdsPatch;->ServerInsertedAdBreakState_enter(Lcom/amazon/avod/media/ads/internal/state/ServerInsertedAdBreakState;Lcom/amazon/avod/media/ads/internal/state/AdBreakTrigger;Lcom/amazon/avod/media/playback/VideoPlayer;)V
+                    return-void
+                """
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
This is a first pass of a patch for Amazon Prime Video to skip ads. Ad breaks seem to be baked into the incoming stream, so the best we can do is force the video player to seek over them.

I could use some help with more extensive testing since the Prime Video app has like 5 different video player implementations and I'm not sure when (if?) the ones that I didn't patch are used.