### PR TITLE
feat(Pandora): Add `disable ads` and `unlimited skips` patches

### DIFF
--- a/extensions/pandora/build.gradle.kts
+++ b/extensions/pandora/build.gradle.kts
@@ -1,0 +1,1 @@
+// Do not remove. Necessary for the extension plugin to be applied to the project.

--- a/extensions/pandora/src/main/AndroidManifest.xml
+++ b/extensions/pandora/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest/>

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/ads/DisableAdsHook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/ads/DisableAdsHook.kt
@@ -1,0 +1,11 @@
+package app.revanced.extension.pandora.ads
+
+import app.revanced.extension.pandora.misc.hook.BaseJsonHook
+import org.json.JSONObject
+
+@Suppress("unused")
+object DisableAdsHook : BaseJsonHook() {
+    override fun apply(json: JSONObject) {
+        json.put("hasAudioAds", false)
+    }
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/BaseJsonHook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/BaseJsonHook.kt
@@ -1,0 +1,9 @@
+package app.revanced.extension.pandora.misc.hook
+
+import org.json.JSONObject
+
+abstract class BaseJsonHook : JsonHook {
+    abstract fun apply(json: JSONObject)
+
+    override fun transform(json: JSONObject) = json.apply { apply(json) }
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/DummyHook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/DummyHook.kt
@@ -1,0 +1,12 @@
+package app.revanced.extension.pandora.misc.hook
+
+import org.json.JSONObject
+
+/**
+ * Dummy hook to reserve a register in [JsonHookPatch.hooks] list.
+ */
+object DummyHook : BaseJsonHook() {
+    override fun apply(json: JSONObject) {
+        // Do nothing.
+    }
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/Hook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/Hook.kt
@@ -1,0 +1,9 @@
+package app.revanced.extension.pandora.misc.hook
+
+interface Hook<T> {
+    /**
+     * Hook the given type.
+     * @param type The type to hook
+     */
+    fun hook(type: T): T
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/JsonHook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/JsonHook.kt
@@ -1,0 +1,14 @@
+package app.revanced.extension.pandora.misc.hook
+
+import org.json.JSONObject
+
+interface JsonHook : Hook<JSONObject> {
+    /**
+     * Transform a JSONObject.
+     *
+     * @param json The JSONObject.
+     */
+    fun transform(json: JSONObject): JSONObject
+
+    override fun hook(type: JSONObject) = transform(type)
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/JsonHookPatch.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/misc/hook/JsonHookPatch.kt
@@ -1,0 +1,16 @@
+package app.revanced.extension.pandora.misc.hook
+
+import org.json.JSONObject
+
+object JsonHookPatch {
+    // Additional hooks added by corresponding patch.
+    private val hooks = buildList<JsonHook> {
+        add(DummyHook)
+    }
+
+    @JvmStatic
+    fun overrideJsonHook(jsonObject: JSONObject) {
+        for (hook in hooks)
+            hook.hook(jsonObject)
+    }
+}

--- a/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/skips/UnlimitedSkipsHook.kt
+++ b/extensions/pandora/src/main/kotlin/app/revanced/extension/pandora/skips/UnlimitedSkipsHook.kt
@@ -1,0 +1,11 @@
+package app.revanced.extension.pandora.skips
+
+import app.revanced.extension.pandora.misc.hook.BaseJsonHook
+import org.json.JSONObject
+
+@Suppress("unused")
+object UnlimitedSkipsHook : BaseJsonHook() {
+    override fun apply(json: JSONObject) {
+        json.put("skipLimitBehavior", "unlimited")
+    }
+}

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -380,6 +380,31 @@ public final class app/revanced/patches/openinghours/misc/fix/crash/FixCrashPatc
 	public static final fun getFixCrashPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/pandora/ads/DisableAdsHookPatchKt {
+	public static final fun getDisableAdsHookPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
+public final class app/revanced/patches/pandora/misc/hook/ExtensionPatchKt {
+	public static final fun getSharedExtensionPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
+public final class app/revanced/patches/pandora/misc/hook/HookPatchKt {
+	public static final fun hookPatch (Ljava/lang/String;Ljava/lang/String;)Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
+public final class app/revanced/patches/pandora/misc/hook/JsonHook {
+	public fun <init> (Lapp/revanced/patcher/patch/BytecodePatchContext;Ljava/lang/String;)V
+}
+
+public final class app/revanced/patches/pandora/misc/hook/JsonHookPatchKt {
+	public static final fun addJsonHook (Lapp/revanced/patcher/patch/BytecodePatchContext;Lapp/revanced/patches/pandora/misc/hook/JsonHook;)V
+	public static final fun getJsonHookPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
+public final class app/revanced/patches/pandora/skips/UnlimitedSkipsHookPatchKt {
+	public static final fun getUnlimitedSkipsHookPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/photomath/detection/deviceid/SpoofDeviceIdPatchKt {
 	public static final fun getGetDeviceIdPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/ads/DisableAdsHookPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/ads/DisableAdsHookPatch.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.pandora.ads
+
+import app.revanced.patches.pandora.misc.hook.hookPatch
+
+@Suppress("unused")
+val disableAdsHookPatch = hookPatch(
+    name = "Disable audio ads",
+    hookClassDescriptor = "Lapp/revanced/extension/pandora/ads/DisableAdsHook;",
+)

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/ExtensionPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/ExtensionPatch.kt
@@ -1,0 +1,5 @@
+package app.revanced.patches.pandora.misc.hook
+
+import app.revanced.patches.shared.misc.extension.sharedExtensionPatch
+
+val sharedExtensionPatch = sharedExtensionPatch("pandora")

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/Fingerprints.kt
@@ -1,0 +1,32 @@
+package app.revanced.patches.pandora.misc.hook
+
+import app.revanced.patcher.fingerprint
+import com.android.tools.smali.dexlib2.Opcode
+
+internal val jsonHookPatchFingerprint = fingerprint {
+    opcodes(
+        Opcode.INVOKE_INTERFACE, // Add dummy hook to hooks list.
+        // Add hooks to the hooks list.
+        Opcode.INVOKE_STATIC, // Call buildList.
+    )
+    custom { method, _ -> method.name == "<clinit>" }
+}
+
+internal val userAuthenticationFingerprint = fingerprint {
+    parameters(
+        "Lorg/json/JSONObject;",
+        "Z",
+        "Z",
+        "I",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Z",
+        "Ljava/lang/String;"
+    )
+    returns("V")
+    strings(
+        "pandoraOneRenewalUrl",
+        "slapViewVideoActivityTitleTextLine2",
+        "slapViewVideoActivityTitleText"
+    )
+}

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/HookPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/HookPatch.kt
@@ -1,0 +1,16 @@
+package app.revanced.patches.pandora.misc.hook
+
+import app.revanced.patcher.patch.bytecodePatch
+
+fun hookPatch(
+    name: String,
+    hookClassDescriptor: String,
+) = bytecodePatch(name) {
+    dependsOn(jsonHookPatch)
+
+    compatibleWith("com.pandora.android")
+
+    execute {
+        addJsonHook(JsonHook(hookClassDescriptor))
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/JsonHookPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/misc/hook/JsonHookPatch.kt
@@ -1,0 +1,102 @@
+package app.revanced.patches.pandora.misc.hook
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
+import app.revanced.patcher.patch.BytecodePatchContext
+import app.revanced.patcher.patch.PatchException
+import app.revanced.patcher.patch.bytecodePatch
+import java.io.InvalidClassException
+
+/**
+ * Add a hook to the [jsonHookPatch].
+ * Will not add the hook if it's already added.
+ *
+ * @param jsonHook The [JsonHook] to add.
+ */
+context(BytecodePatchContext)
+fun addJsonHook(
+    jsonHook: JsonHook,
+) {
+    if (jsonHook.added) return
+
+    jsonHookPatchFingerprint.method.apply {
+        // Insert hooks right before calling buildList.
+        val insertIndex = jsonHookPatchFingerprint.patternMatch!!.endIndex
+
+        addInstructions(
+            insertIndex,
+            """
+                sget-object v1, ${jsonHook.descriptor}->INSTANCE:${jsonHook.descriptor}
+                invoke-interface {v0, v1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+            """,
+        )
+    }
+
+    jsonHook.added = true
+}
+
+private const val JSON_HOOK_CLASS_NAMESPACE = "app/revanced/extension/pandora/misc/hook"
+private const val JSON_HOOK_PATCH_CLASS_DESCRIPTOR = "L$JSON_HOOK_CLASS_NAMESPACE/JsonHookPatch;"
+private const val BASE_PATCH_CLASS_NAME = "BaseJsonHook"
+private const val JSON_HOOK_CLASS_DESCRIPTOR = "L$JSON_HOOK_CLASS_NAMESPACE/$BASE_PATCH_CLASS_NAME;"
+
+val jsonHookPatch = bytecodePatch(
+    description = "Hooks the stream which reads JSON responses.",
+) {
+    dependsOn(sharedExtensionPatch)
+
+    execute {
+        jsonHookPatchFingerprint.apply {
+            // Make sure the extension is present.
+            val jsonHookPatch = classBy { classDef -> classDef.type == JSON_HOOK_PATCH_CLASS_DESCRIPTOR }
+                ?: throw PatchException("Could not find the extension.")
+
+            matchOrNull(jsonHookPatch.immutableClass)
+                ?: throw PatchException("Unexpected extension.")
+        }
+
+        // Send authentication JSONObject to our extension for patching modification.
+        userAuthenticationFingerprint.method.addInstruction(
+            2,
+            "invoke-static { v0 }, $JSON_HOOK_PATCH_CLASS_DESCRIPTOR->overrideJsonHook(Lorg/json/JSONObject;)V"
+        )
+    }
+
+    finalize {
+        // Remove hooks.add(dummyHook).
+        jsonHookPatchFingerprint.method.apply {
+            val addDummyHookIndex = jsonHookPatchFingerprint.patternMatch!!.endIndex - 2
+
+            removeInstructions(addDummyHookIndex, 2)
+        }
+    }
+}
+
+/**
+ * Create a hook class.
+ * The class has to extend on **JsonHook**.
+ * The class has to be a Kotlin object class, or at least have an INSTANCE field of itself.
+ *
+ * @param descriptor The class descriptor of the hook.
+ * @throws ClassNotFoundException If the class could not be found.
+ */
+context(BytecodePatchContext)
+class JsonHook(
+    internal val descriptor: String,
+) {
+    internal var added = false
+
+    init {
+        classBy { it.type == descriptor }?.let {
+            it.mutableClass.also { classDef ->
+                if (
+                    classDef.superclass != JSON_HOOK_CLASS_DESCRIPTOR ||
+                    !classDef.fields.any { field -> field.name == "INSTANCE" }
+                ) {
+                    throw InvalidClassException(classDef.type, "Not a hook class")
+                }
+            }
+        } ?: throw ClassNotFoundException("Failed to find hook class $descriptor")
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/pandora/skips/UnlimitedSkipsHookPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/pandora/skips/UnlimitedSkipsHookPatch.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.pandora.skips
+
+import app.revanced.patches.pandora.misc.hook.hookPatch
+
+@Suppress("unused")
+val unlimitedSkipsHookPatch = hookPatch(
+    name = "Unlimited skips",
+    hookClassDescriptor = "Lapp/revanced/extension/pandora/skips/UnlimitedSkipsHook;",
+)


### PR DESCRIPTION
Couple patches for Pandora for feature request #4836 

`Unlimited skips` is pretty self-explanatory. `Disable ads` only gets rid of in-radio, audio ads. Most of the on-demand features for premium subscriptions (eg. play specific song/album, artist only radio stations) seem to rely on server-side functionality. Not positive on this, but would make sense why I couldn't get it to work.

There is currently a lot of copied code from a similar twitter feature in this PR. I was attempting to abstract things out to keep it DRY, but I got tired of fighting gradle errors on the extension side. I'll make some comments on the code to show how things differ from Twitter if some kind soul wants to refactor.