### PR TITLE
feat(NU.nl): Support version 11.3.0

### DIFF
--- a/extensions/nunl/src/main/java/app/revanced/extension/nunl/ads/HideAdsPatch.java
+++ b/extensions/nunl/src/main/java/app/revanced/extension/nunl/ads/HideAdsPatch.java
@@ -82,7 +82,7 @@ public class HideAdsPatch {
 
                 // Filter HeaderBlock with known ads until next HeaderBlock.
                 if (currentBlock instanceof HeaderBlock headerBlock) {
-                    StyledText headerText = headerBlock.component20();
+                    StyledText headerText = headerBlock.getTitle();
                     if (headerText != null) {
                         skipFullHeader = false;
                         for (String blockedHeaderBlock : blockedHeaderBlocks) {

--- a/extensions/nunl/stub/src/main/java/nl/nu/performance/api/client/objects/HeaderBlock.java
+++ b/extensions/nunl/stub/src/main/java/nl/nu/performance/api/client/objects/HeaderBlock.java
@@ -3,8 +3,7 @@ package nl.nu.performance.api.client.objects;
 import nl.nu.performance.api.client.interfaces.Block;
 
 public class HeaderBlock extends Block {
-    // returns title
-    public final StyledText component20() {
+    public final StyledText getTitle() {
         throw new UnsupportedOperationException("Stub");
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/nunl/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/nunl/ads/Fingerprints.kt
@@ -4,10 +4,10 @@ import app.revanced.patcher.fingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
-internal val jwUtilCreateAdvertisementFingerprint = fingerprint {
-    accessFlags(AccessFlags.PRIVATE, AccessFlags.STATIC)
+internal val jwPlayerConfigFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC)
     custom { methodDef, classDef ->
-        classDef.type == "Lnl/sanomamedia/android/nu/video/util/JWUtil;" && methodDef.name == "createAdvertising"
+        classDef.type == "Lcom/jwplayer/pub/api/configuration/PlayerConfig${'$'}Builder;" && methodDef.name == "advertisingConfig"
     }
 }
 

--- a/patches/src/main/kotlin/app/revanced/patches/nunl/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/nunl/ads/HideAdsPatch.kt
@@ -2,6 +2,7 @@ package app.revanced.patches.nunl.ads
 
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
 import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.patches.shared.misc.extension.sharedExtensionPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -11,23 +12,14 @@ val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
     description = "Hide ads and sponsored articles in list pages and remove pre-roll ads on videos.",
 ) {
-    compatibleWith("nl.sanomamedia.android.nu"("11.0.0", "11.0.1", "11.1.0"))
+    compatibleWith("nl.sanomamedia.android.nu"("11.3.0"))
 
     dependsOn(sharedExtensionPatch("nunl", mainActivityOnCreateHook))
 
     execute {
         // Disable video pre-roll ads.
-        // Whenever the app tries to create an ad via JWUtils.createAdvertising, don't actually tell the underlying JWPlayer library to do so => JWPlayer will not display ads.
-        jwUtilCreateAdvertisementFingerprint.method.addInstructions(
-            0,
-            """
-                new-instance v0, Lcom/jwplayer/pub/api/configuration/ads/VastAdvertisingConfig${'$'}Builder;
-                invoke-direct { v0 }, Lcom/jwplayer/pub/api/configuration/ads/VastAdvertisingConfig${'$'}Builder;-><init>()V
-                invoke-virtual { v0 }, Lcom/jwplayer/pub/api/configuration/ads/VastAdvertisingConfig${'$'}Builder;->build()Lcom/jwplayer/pub/api/configuration/ads/VastAdvertisingConfig;
-                move-result-object v0
-                return-object v0
-            """,
-        )
+        // Whenever the app tries to define the advertising config for JWPlayer, don't set the advertising config and directly return.
+        jwPlayerConfigFingerprint.method.removeInstructions(1)
 
         // Filter injected content from API calls out of lists.
         arrayOf(screenMapperFingerprint, nextPageRepositoryImplFingerprint).forEach {


### PR DESCRIPTION
Removes support for older versions as:

1. older versions start showing errors about needing to update the app in more and more spots
2. interface of the HeaderBlock changed and adding specific version checks for that would be more work than just updating to the latest version of the app

Adjusted video adblocker method as the developer of the app got rid of their own `JWUtil` class. This patch now directly intercepts setting the advertising config as described here https://docs.jwplayer.com/players/docs/android-schedule-google-ima-ads