### PR TITLE
feat(Angulus): Adding `Disable license check` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -144,6 +144,10 @@ public final class app/revanced/patches/angulus/ads/RemoveAdsPatchKt {
 	public static final fun getAngulusPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/angulus/misc/license/DisableLicenseCheckPatchKt {
+	public static final fun getDisableLicenseCheckPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/backdrops/misc/pro/ProUnlockPatchKt {
 	public static final fun getProUnlockPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/angulus/misc/license/DisableLicenseCheckPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/angulus/misc/license/DisableLicenseCheckPatch.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.angulus.misc.license
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.util.returnEarly
+
+@Suppress("unused")
+val disableLicenseCheckPatch = bytecodePatch(
+    name = "Disable license check",
+    description = "Disable client-side license check to prevent app from closing on startup."
+) {
+    compatibleWith("com.drinkplusplus.angulus"("5.0.20"))
+
+    execute {
+        // Set first parameter (responseCode) to 0.
+        processLicenseResponseFingerprint.method.addInstruction(0, "const/4 p1, 0x0")
+
+        // Short-circuit the license response validation.
+        validateLicenseResponseFingerprint.method.returnEarly();
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/angulus/misc/license/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/angulus/misc/license/Fingerprints.kt
@@ -1,0 +1,17 @@
+package app.revanced.patches.angulus.misc.license
+
+import app.revanced.patcher.fingerprint
+
+internal val processLicenseResponseFingerprint = fingerprint {
+    custom { method, classDef ->
+        classDef.type == "Lcom/pairip/licensecheck/LicenseClient;" &&
+                method.name == "processResponse"
+    }
+}
+
+internal val validateLicenseResponseFingerprint = fingerprint {
+    custom { method, classDef ->
+        classDef.type == "Lcom/pairip/licensecheck/ResponseValidator;" &&
+                method.name == "validateResponse"
+    }
+}


### PR DESCRIPTION
Just a simple, little patch to bypass the client-side validation of the Google Play Licensing response. This should work for any app that only does the client validation (if we want to move the code to a shared location.)

Fixes #4776