### PR TITLE
feat(Proton Mail): Add `Change free accounts limit` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -432,6 +432,10 @@ public final class app/revanced/patches/primevideo/misc/extension/ExtensionPatch
 	public static final fun getSharedExtensionPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/protonmail/account/ChangeFreeAccountsLimitKt {
+	public static final fun getChangeFreeAccountsLimit ()Lapp/revanced/patcher/patch/ResourcePatch;
+}
+
 public final class app/revanced/patches/protonmail/signature/RemoveSentFromSignaturePatchKt {
 	public static final fun getRemoveSentFromSignaturePatch ()Lapp/revanced/patcher/patch/ResourcePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/protonmail/account/ChangeFreeAccountsLimit.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/protonmail/account/ChangeFreeAccountsLimit.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.protonmail.account
+
+import app.revanced.patcher.patch.intOption
+import app.revanced.patcher.patch.resourcePatch
+import app.revanced.util.findElementByAttributeValueOrThrow
+
+private const val ACCOUNT_LIMIT = 10
+
+@Suppress("unused")
+val changeFreeAccountsLimit = resourcePatch(
+    name = "Change free accounts limit",
+    description = "Applies a custom limit for maximum free accounts logged in. Defaults to \"10\".",
+) {
+    compatibleWith("ch.protonmail.android")
+
+    val limit by intOption(
+        key = "limit",
+        default = ACCOUNT_LIMIT,
+        title = "Account limit",
+        description = "The maximum number of free accounts allowed.",
+    )
+
+    execute {
+        document("res/values/integers.xml").use { document ->
+            document.documentElement.childNodes.findElementByAttributeValueOrThrow(
+                "name",
+                "core_feature_auth_user_check_max_free_user_count",
+            ).textContent = limit.toString()
+        }
+    }
+}


### PR DESCRIPTION
This patch modifies the max "Free" accounts restriction in Proton Mail (by default, the limit is **2 accounts**).

- Accepts customization with an option; the default being `10` accounts.

Working as of Proton Mail 4.10.0

Closes #4965