### PR TITLE
feat(Telegram): Add `Remove birthday input message` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -920,6 +920,10 @@ public final class app/revanced/patches/swissid/integritycheck/RemoveGooglePlayI
 	public static final fun getRemoveGooglePlayIntegrityCheckPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/telegram/birthday/HideBirthdayMessageKt {
+	public static final fun getRemoveBirthdayMassagePatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/ticktick/misc/themeunlock/UnlockThemePatchKt {
 	public static final fun getUnlockProPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/Fingerprints.kt
@@ -11,10 +11,10 @@ internal val birthdayStateFingerprint = fingerprint {
     parameters()
     opcodes(
             Opcode.MOVE_RESULT,
-            Opcode.OP_IF_EQZ,
+            Opcode.IF_EQZ,
             Opcode.RETURN_OBJECT
     )
     custom { methodDef, classDef ->
-        methodDef.name == "getState" && classDef.endsWith("/BirtdayController;")
+        methodDef.name == "getState" && classDef.endsWith("/BirthdayController;")
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/Fingerprints.kt
@@ -1,0 +1,20 @@
+package app.revanced.patches.telegram.birthday
+
+import app.revanced.patcher.fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+// Located @ org.telegram.messenger.BirthdayController#getState
+internal val birthdayStateFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC)
+    returns("Lorg/telegram/messenger/BirthdayController\$BirthdayState")
+    parameters()
+    opcodes(
+            Opcode.MOVE_RESULT,
+            Opcode.OP_IF_EQZ,
+            Opcode.RETURN_OBJECT
+    )
+    custom { methodDef, classDef ->
+        methodDef.name == "getState" && classDef.endsWith("/BirtdayController;")
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/HideBirthdayMessage.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/HideBirthdayMessage.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.telegram.birthday
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
+import app.revanced.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val removeBirthdayMassagePatch = bytecodePatch(
+    name = "Remove birthday input message",
+    description = "Removes the message asking for your birthday.",
+) {
+    compatibleWith("org.telegram.messenger")
+
+    execute {
+        birthdayStateFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return-object v0
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/HideBirthdayMessage.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/telegram/birthday/HideBirthdayMessage.kt
@@ -10,6 +10,7 @@ val removeBirthdayMassagePatch = bytecodePatch(
 ) {
     compatibleWith("org.telegram.messenger")
 
+    // Return null early. This is also done, when the message is supposed to be hidden.
     execute {
         birthdayStateFingerprint.method.addInstructions(
             0,


### PR DESCRIPTION
When opening the app the user is frequently asked about their birthday. Dismissing this hiddes the message for around a day. This patch hides the message indefinitely.