### PR TITLE
fix(YouTube): Support A/B Shorts layout for RYD and component hiding

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/ReturnYouTubeDislikePatch.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/ReturnYouTubeDislikePatch.java
@@ -152,11 +152,15 @@ public class ReturnYouTubeDislikePatch {
                 return original; // No need to check for Shorts in the context.
             }
 
-            if (conversionContextString.contains("|shorts_dislike_button.eml")) {
+            if (Utils.containsAny(conversionContextString,
+                    "|shorts_dislike_button.eml", "|reel_dislike_button.eml"
+            )) {
                 return getShortsSpan(original, true);
             }
 
-            if (conversionContextString.contains("|shorts_like_button.eml")) {
+            if (Utils.containsAny(conversionContextString,
+                    "|shorts_like_button.eml", "|reel_like_button.eml"
+            )) {
                 if (!Utils.containsNumber(original)) {
                     Logger.printDebug(() -> "Replacing hidden likes count");
                     return getShortsSpan(original, false);

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/ShortsFilter.java
@@ -143,12 +143,14 @@ public final class ShortsFilter extends Filter {
 
         StringFilterGroup likeButton = new StringFilterGroup(
                 Settings.HIDE_SHORTS_LIKE_BUTTON,
-                "shorts_like_button.eml"
+                "shorts_like_button.eml",
+                "reel_like_button.eml"
         );
 
         StringFilterGroup dislikeButton = new StringFilterGroup(
                 Settings.HIDE_SHORTS_DISLIKE_BUTTON,
-                "shorts_dislike_button.eml"
+                "shorts_dislike_button.eml",
+                "reel_dislike_button.eml"
         );
 
         joinButton = new StringFilterGroup(
@@ -168,12 +170,13 @@ public final class ShortsFilter extends Filter {
 
         shortsActionBar = new StringFilterGroup(
                 null,
-                "shorts_action_bar.eml"
+                "shorts_action_bar.eml",
+                "reel_action_bar.eml"
         );
 
         actionButton = new StringFilterGroup(
                 null,
-                // Can be simply 'button.eml' or 'shorts_video_action_button.eml'
+                // Can be simply 'button.eml', 'shorts_video_action_button.eml' or 'reel_action_button.eml'
                 "button.eml"
         );
 
@@ -195,15 +198,18 @@ public final class ShortsFilter extends Filter {
         videoActionButtonGroupList.addAll(
                 new ByteArrayFilterGroup(
                         Settings.HIDE_SHORTS_COMMENTS_BUTTON,
-                        "reel_comment_button"
+                        "reel_comment_button",
+                        "youtube_shorts_comment_outline"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_SHORTS_SHARE_BUTTON,
-                        "reel_share_button"
+                        "reel_share_button",
+                        "youtube_shorts_share_outline"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_SHORTS_REMIX_BUTTON,
-                        "reel_remix_button"
+                        "reel_remix_button",
+                        "youtube_shorts_remix_outline"
                 )
         );
 


### PR DESCRIPTION
Adds support for a new Shorts layout currently being A/B tested. Resolves #5024.

RYD works fine, component hiding also works fine. However I couldn't test **stickers** and **like fountain** toggles as I could not get them to show.

It looks like YouTube also turned all the buttons in "All other action buttons" into `reel_action_button.eml`, so now they can only be hidden using their icons. Should the filters for those be shortened in case YouTube renames the icons in the future?