### PR TITLE
fix(Spotify): Prevent hiding all navigation bar buttons

### DIFF
--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/layout/hide/createbutton/HideCreateButtonPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/layout/hide/createbutton/HideCreateButtonPatch.java
@@ -37,6 +37,11 @@ public final class HideCreateButtonPatch {
         String matchedTitleResId = null;
 
         for (String titleResId : CREATE_BUTTON_TITLE_RES_ID_LIST) {
+            // In case the resource id has not been found.
+            if (titleResId.equals("0")) {
+                continue;
+            }
+
             if (stringifiedNavigationBarItem.contains(titleResId)) {
                 isCreateButton = true;
                 matchedTitleResId = titleResId;
@@ -58,6 +63,11 @@ public final class HideCreateButtonPatch {
      * Create button.
      */
     public static boolean isOldCreateButton(int oldNavigationBarItemTitleResId) {
+        // In case the resource id has not been found.
+        if (OLD_CREATE_BUTTON_TITLE_RES_ID == 0) {
+            return false;
+        }
+
         boolean isCreateButton = oldNavigationBarItemTitleResId == OLD_CREATE_BUTTON_TITLE_RES_ID;
 
         if (isCreateButton) {

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
@@ -3,7 +3,6 @@ package app.revanced.extension.spotify.misc;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
-import androidx.annotation.NonNull;
 import com.spotify.home.evopage.homeapi.proto.Section;
 
 import java.util.Iterator;
@@ -124,7 +123,6 @@ public final class UnlockPremiumPatch {
     /**
      * Utility method for returning resources ids as strings.
      */
-    @NonNull
     private static String getResourceIdentifier(String resourceIdentifierName) {
         return Integer.toString(Utils.getResourceIdentifier(resourceIdentifierName, "id"));
     }

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/UnlockPremiumPatch.java
@@ -3,6 +3,7 @@ package app.revanced.extension.spotify.misc;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
+import androidx.annotation.NonNull;
 import com.spotify.home.evopage.homeapi.proto.Section;
 
 import java.util.Iterator;
@@ -123,6 +124,7 @@ public final class UnlockPremiumPatch {
     /**
      * Utility method for returning resources ids as strings.
      */
+    @NonNull
     private static String getResourceIdentifier(String resourceIdentifierName) {
         return Integer.toString(Utils.getResourceIdentifier(resourceIdentifierName, "id"));
     }
@@ -216,6 +218,12 @@ public final class UnlockPremiumPatch {
 
             for (int i = 0; i < stringList.size(); i++) {
                 String string = stringList.get(i);
+
+                // In case the string is a resource id, and it has not been found.
+                if (string.equals("0")) {
+                    continue;
+                }
+
                 if (!stringifiedContextMenuItem.contains(string)) {
                     allMatch = false;
                     break;


### PR DESCRIPTION
Just now realized this issue. I saw some users claiming all navigation bar items were getting hidden, and this might be why.