### PR TITLE
fix(Bandcamp): Fix "Remove play limits` patch to work with latest version

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/bandcamp/limitations/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/bandcamp/limitations/Fingerprints.kt
@@ -3,5 +3,5 @@ package app.revanced.patches.bandcamp.limitations
 import app.revanced.patcher.fingerprint
 
 internal val handlePlaybackLimitsFingerprint = fingerprint {
-    strings("play limits processing track", "found play_count")
+    strings("track_id", "play_count")
 }

--- a/patches/src/main/kotlin/app/revanced/patches/bandcamp/limitations/RemovePlayLimitsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/bandcamp/limitations/RemovePlayLimitsPatch.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.bandcamp.limitations
 
-import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.util.returnEarly
 
 @Suppress("unused")
 val removePlayLimitsPatch = bytecodePatch(
@@ -11,6 +11,6 @@ val removePlayLimitsPatch = bytecodePatch(
     compatibleWith("com.bandcamp.android")
 
     execute {
-        handlePlaybackLimitsFingerprint.method.addInstructions(0, "return-void")
+        handlePlaybackLimitsFingerprint.method.returnEarly()
     }
 }


### PR DESCRIPTION
Strings for fingerprint changed. This update should be backwards compatible. Patched method has slightly different logic from last version, but seems to work. 

Reported in #5114 