### PR TITLE
feat(Messenger - Remove Meta AI): Improve patch logic

### DIFF
--- a/extensions/messenger/src/main/java/app/revanced/extension/messenger/metaai/RemoveMetaAIPatch.java
+++ b/extensions/messenger/src/main/java/app/revanced/extension/messenger/metaai/RemoveMetaAIPatch.java
@@ -1,14 +1,21 @@
 package app.revanced.extension.messenger.metaai;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import app.revanced.extension.shared.Logger;
+
 @SuppressWarnings("unused")
 public class RemoveMetaAIPatch {
+    private static final Set<Long> loggedIDs = new HashSet<>();
+
     public static boolean overrideBooleanFlag(long id, boolean value) {
-        // This catches all flag IDs related to Meta AI.
-        // The IDs change slightly with every update,
-        // so to work around this, IDs from different versions were compared
-        // to find what they have in common, which turned out to be those first bits.
-        // TODO: Find the specific flags that we care about and patch the code they control instead.
-        if ((id & 0x7FFFFFC000000000L) == 0x810A8000000000L) {
+        if (Long.toString(id).startsWith("REPLACED_BY_PATCH")) {
+            synchronized (loggedIDs) {
+                if (loggedIDs.add(id)) {
+                    Logger.printInfo(() -> "Overriding " + id + " from " + value + " to false");
+                }
+            }
             return false;
         }
 

--- a/patches/src/main/kotlin/app/revanced/patches/messenger/metaai/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/messenger/metaai/Fingerprints.kt
@@ -1,7 +1,10 @@
 package app.revanced.patches.messenger.metaai
 
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.AccessFlags
 import app.revanced.patcher.fingerprint
+
+internal const val EXTENSION_METHOD_DESCRIPTOR = "Lapp/revanced/extension/messenger/metaai/RemoveMetaAIPatch;->overrideBooleanFlag(JZ)Z"
 
 internal val getMobileConfigBoolFingerprint = fingerprint {
     parameters("J")
@@ -9,5 +12,23 @@ internal val getMobileConfigBoolFingerprint = fingerprint {
     opcodes(Opcode.RETURN)
     custom { _, classDef ->
         classDef.interfaces.contains("Lcom/facebook/mobileconfig/factory/MobileConfigUnsafeContext;")
+    }
+}
+
+internal val relevantIDContainingMethodFingerprint = fingerprint {
+    returns("Z")
+    accessFlags(AccessFlags.PUBLIC, AccessFlags.STATIC)
+    parameters("L", "L", "I")
+    strings("SearchAiagentImplementationsKillSwitch")
+    opcodes(Opcode.CONST_WIDE)
+}
+
+internal val extensionMethodFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC, AccessFlags.STATIC)
+    parameters("J", "Z")
+    returns("Z")
+    strings("REPLACED_BY_PATCH")
+    custom { method, _ ->
+        method.toString() == EXTENSION_METHOD_DESCRIPTOR
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/messenger/misc/extension/ExtensionPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/messenger/misc/extension/ExtensionPatch.kt
@@ -2,4 +2,4 @@ package app.revanced.patches.messenger.misc.extension
 
 import app.revanced.patches.shared.misc.extension.sharedExtensionPatch
 
-val sharedExtensionPatch = sharedExtensionPatch("messenger", mainActivityOnCreateHook)
+val sharedExtensionPatch = sharedExtensionPatch("messenger", messengerApplicationOnCreateHook)

--- a/patches/src/main/kotlin/app/revanced/patches/messenger/misc/extension/Hooks.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/messenger/misc/extension/Hooks.kt
@@ -2,6 +2,8 @@ package app.revanced.patches.messenger.misc.extension
 
 import app.revanced.patches.shared.misc.extension.extensionHook
 
-internal val mainActivityOnCreateHook = extensionHook {
-    strings("MainActivity_onCreate_begin")
+internal val messengerApplicationOnCreateHook = extensionHook {
+    custom { method, classDef ->
+        method.name == "onCreate" && classDef.endsWith("/MessengerApplication;")
+    }
 }


### PR DESCRIPTION
The patch as it is now can have side effects (disabling non-Meta AI features) because its ID matching logic is too loose, because it accounts for the IDs changing across app versions. Now it targets only Meta AI config flags, by extracting the starting digits specific to the app version from code. Also added logging of the overriden flags, for potential future debugging.

TODO: write some comments explaining what's going on