### PR TITLE
fix(YouTube - Comments): Fix "Hide AI Comments summary"

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/CommentsFilter.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/components/CommentsFilter.java
@@ -52,7 +52,7 @@ final class CommentsFilter extends Filter {
 
         filterChipBar = new StringFilterGroup(
                 Settings.HIDE_COMMENTS_AI_SUMMARY,
-                "filter_chip_bar.eml"
+                "chip_bar.eml"
         );
 
         aiCommentsSummary = new ByteArrayFilterGroup(


### PR DESCRIPTION
Closes #5263.