### PR TITLE
ci: Remove fetch-depth from checkout

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/pull_strings.yml
+++ b/.github/workflows/pull_strings.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: dev
-          fetch-depth: 0
           clean: true
 
       - name: Pull strings

--- a/.github/workflows/push_strings.yml
+++ b/.github/workflows/push_strings.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Preprocess strings
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
> [!NOTE]
> Tested™️ with semantic release, everything works fine, 
> 
> sees https://github.com/validcube/revanced-patches-2/actions/runs/16025053735/job/45210839636
> (The CI failed because the changelog it generated for my repo is too large to be included in a single release/tag description)

Why fetch *all* commit history when we are not going to use them. 

### Linked PR

##### To be updated, but for now--for my own information--in case I forgot it: https://trello.com/c/xWPgKGaO/7-revanced-ci-template-01-07-2025