### PR TITLE
ci: Group all Dependabot update into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,25 @@
 version: 2
+multi-ecosystem-groups:
+  dependency:
+    schedule:
+      interval: "weekly"
+      target-branch: dev
+
 updates:
   - package-ecosystem: github-actions
-    labels: []
+    multi-ecosystem-group: "dependency"
     directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
+    patterns:
+      - "*"
 
   - package-ecosystem: npm
-    labels: []
+    multi-ecosystem-group: "dependency"
     directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
+    patterns:
+      - "*"
 
   - package-ecosystem: gradle
-    labels: []
+    multi-ecosystem-group: "dependency"
     directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
+    patterns:
+      - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
     schedule:
       interval: "weekly"
       target-branch: dev
+      labels: [ ]
 
 updates:
   - package-ecosystem: github-actions


### PR DESCRIPTION
This feature is too new to be included in GitHub Documentation... :trollface: good luck extending! 

https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support/