### PR TITLE
feat(YouTube): Disable two-finger tap gesture for skipping chapters

### DIFF
--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/DisableChapterSkipDoubleTapPatch.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/DisableChapterSkipDoubleTapPatch.java
@@ -4,7 +4,12 @@ import app.revanced.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public final class DisableChapterSkipDoubleTapPatch {
-    // Returns the updated value for the "should skip to chapter start" flag
+
+    /**
+     * Injection point.
+     *
+     * @return If "should skip to chapter start" flag is set.
+     */
     public static boolean disableDoubleTapChapters(boolean original) {
         return original && !Settings.DISABLE_CHAPTER_SKIP_DOUBLE_TAP.get();
     }

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/DisableChapterSkipDoubleTapPatch.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/patches/DisableChapterSkipDoubleTapPatch.java
@@ -1,0 +1,11 @@
+package app.revanced.extension.youtube.patches;
+
+import app.revanced.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public final class DisableChapterSkipDoubleTapPatch {
+    // Returns the updated value for the "should skip to chapter start" flag
+    public static boolean disableDoubleTapChapters(boolean original) {
+        return original && !Settings.DISABLE_CHAPTER_SKIP_DOUBLE_TAP.get();
+    }
+}

--- a/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/revanced/extension/youtube/settings/Settings.java
@@ -146,6 +146,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting COPY_VIDEO_URL = new BooleanSetting("revanced_copy_video_url", FALSE);
     public static final BooleanSetting COPY_VIDEO_URL_TIMESTAMP = new BooleanSetting("revanced_copy_video_url_timestamp", TRUE);
     public static final BooleanSetting DISABLE_AUTO_CAPTIONS = new BooleanSetting("revanced_disable_auto_captions", FALSE, true);
+    public static final BooleanSetting DISABLE_CHAPTER_SKIP_DOUBLE_TAP = new BooleanSetting("revanced_disable_chapter_skip_double_tap", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_AMBIENT_MODE = new BooleanSetting("revanced_disable_fullscreen_ambient_mode", TRUE, true);
     public static final BooleanSetting DISABLE_ROLLING_NUMBER_ANIMATIONS = new BooleanSetting("revanced_disable_rolling_number_animations", FALSE);
     public static final EnumSetting<FullscreenMode> EXIT_FULLSCREEN = new EnumSetting<>("revanced_exit_fullscreen", FullscreenMode.DISABLED);

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -1228,6 +1228,10 @@ public final class app/revanced/patches/youtube/interaction/dialog/RemoveViewerD
 	public static final fun getRemoveViewerDiscretionDialogPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatchKt {
+	public static final fun getDisableChapterSkipDoubleTapPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/youtube/interaction/downloads/DownloadsPatchKt {
 	public static final fun getDownloadsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -1,16 +1,21 @@
 package app.revanced.patches.youtube.interaction.doubletap
 
-import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patches.all.misc.resources.addResources
 import app.revanced.patches.all.misc.resources.addResourcesPatch
+import app.revanced.patches.shared.misc.settings.preference.SwitchPreference
 import app.revanced.patches.youtube.misc.extension.sharedExtensionPatch
+import app.revanced.patches.youtube.misc.settings.PreferenceScreen
 import app.revanced.patches.youtube.misc.settings.settingsPatch
+
+private const val EXTENSION_CLASS_DESCRIPTOR =
+    "Lapp/revanced/extension/youtube/patches/DisableChapterSkipDoubleTapPatch;"
 
 @Suppress("unused")
 val disableChapterSkipDoubleTapPatch = bytecodePatch(
     name = "Disable double tap chapter skip",
     description = "Prevents the double tap gesture from ever skipping to the next/previous chapter.",
-    use = false,
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -26,11 +31,23 @@ val disableChapterSkipDoubleTapPatch = bytecodePatch(
     )
 
     execute {
+        addResources("youtube", "interaction.doubletap.disableChapterSkipDoubleTapPatch")
+
+        PreferenceScreen.PLAYER.addPreferences(
+            SwitchPreference("revanced_disable_chapter_skip_double_tap"),
+        )
+
         val classDef = chapterSeekResultToStringFingerprint.classDef
 
         chapterSeekResultCtorFingerprint.match(classDef).method.apply {
             // Resets the isSeekingToChapterStart flag to false
-            addInstruction(0, "const/4 p1, 0x0")
+            addInstructions(
+                0,
+                """
+                    invoke-static { p1 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
+                    move-result p1
+                """,
+            )
         }
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -1,0 +1,36 @@
+package app.revanced.patches.youtube.interaction.doubletap
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patches.all.misc.resources.addResourcesPatch
+import app.revanced.patches.youtube.misc.extension.sharedExtensionPatch
+import app.revanced.patches.youtube.misc.settings.settingsPatch
+
+@Suppress("unused")
+val disableChapterSkipDoubleTapPatch = bytecodePatch(
+    name = "Disable double tap chapter skip",
+    description = "Prevents the double tap gesture from ever skipping to the next/previous chapter.",
+    use = false,
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+        addResourcesPatch,
+    )
+
+    compatibleWith(
+        "com.google.android.youtube"(
+            // Possibly earlier too, but I don't care about that personally
+            "20.13.41",
+        )
+    )
+
+    execute {
+        val classDef = chapterSeekResultToStringFingerprint.classDef
+
+        chapterSeekResultCtorFingerprint.match(classDef).method.apply {
+            // Resets the isSeekingToChapterStart flag to false
+            addInstruction(0, "const/4 p1, 0x0")
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -37,15 +37,24 @@ val disableChapterSkipDoubleTapPatch = bytecodePatch(
             SwitchPreference("revanced_disable_chapter_skip_double_tap"),
         )
 
-        val classDef = chapterSeekResultToStringFingerprint.classDef
-
-        chapterSeekResultCtorFingerprint.match(classDef).method.apply {
-            // Resets the isSeekingToChapterStart flag to false
+        doubleTapInfoGetSeekSourceFingerprint.method.apply {
+            // Resets the isChapterSeek flag to false
             addInstructions(
                 0,
                 """
                     invoke-static { p1 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
                     move-result p1
+                """,
+            )
+        }
+
+        doubleTapInfoCtorFingerprint.match(doubleTapInfoGetSeekSourceFingerprint.classDef).method.apply {
+            // Resets the isChapterSeek flag to false
+            addInstructions(
+                0,
+                """
+                    invoke-static { p3 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
+                    move-result p3
                 """,
             )
         }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -14,8 +14,8 @@ private const val EXTENSION_CLASS_DESCRIPTOR =
 
 @Suppress("unused")
 val disableChapterSkipDoubleTapPatch = bytecodePatch(
-    name = "Disable double tap chapter skip",
-    description = "Prevents the double tap gesture from ever skipping to the next/previous chapter.",
+    name = "Disable double tap actions",
+    description = "Adds an option to disable player double tap gestures.",
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -25,7 +25,11 @@ val disableChapterSkipDoubleTapPatch = bytecodePatch(
 
     compatibleWith(
         "com.google.android.youtube"(
-            // Possibly earlier too, but I don't care about that personally
+            "19.34.42",
+            "19.43.41",
+            "19.47.53",
+            "20.07.39",
+            "20.12.46",
             "20.13.41",
         )
     )
@@ -37,26 +41,22 @@ val disableChapterSkipDoubleTapPatch = bytecodePatch(
             SwitchPreference("revanced_disable_chapter_skip_double_tap"),
         )
 
-        doubleTapInfoGetSeekSourceFingerprint.method.apply {
-            // Resets the isChapterSeek flag to false
-            addInstructions(
-                0,
-                """
-                    invoke-static { p1 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
-                    move-result p1
-                """,
-            )
-        }
+        // Force isChapterSeek flag to false.
+        doubleTapInfoGetSeekSourceFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static { p1 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
+                move-result p1
+            """
+        )
 
-        doubleTapInfoCtorFingerprint.match(doubleTapInfoGetSeekSourceFingerprint.classDef).method.apply {
-            // Resets the isChapterSeek flag to false
-            addInstructions(
-                0,
-                """
-                    invoke-static { p3 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
-                    move-result p3
-                """,
-            )
-        }
+        doubleTapInfoCtorFingerprint.match(
+            doubleTapInfoGetSeekSourceFingerprint.classDef
+        ).method.addInstructions(
+            0, """
+                invoke-static { p3 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
+                move-result p3
+            """
+        )
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -53,7 +53,8 @@ val disableChapterSkipDoubleTapPatch = bytecodePatch(
         doubleTapInfoCtorFingerprint.match(
             doubleTapInfoGetSeekSourceFingerprint.classDef
         ).method.addInstructions(
-            0, """
+            0,
+            """
                 invoke-static { p3 }, $EXTENSION_CLASS_DESCRIPTOR->disableDoubleTapChapters(Z)Z
                 move-result p3
             """

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -1,0 +1,24 @@
+package app.revanced.patches.youtube.interaction.doubletap
+
+import app.revanced.patcher.fingerprint
+
+internal val chapterSeekResultToStringFingerprint = fingerprint {
+    parameters()
+    returns("Ljava/lang/String;")
+    strings(
+        "ChapterSeekResult{isSeekingToChapterStart=",
+        ", seekDuration=",
+        ", seekText=",
+        ", isOverlayCentered=",
+        "}",
+    )
+    custom { method, _ ->
+        method.name == "toString"
+    }
+}
+
+internal val chapterSeekResultCtorFingerprint = fingerprint {
+    custom { method, _ ->
+        method.name == "<init>" && method.parameters.isNotEmpty()
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -1,6 +1,7 @@
 package app.revanced.patches.youtube.interaction.doubletap
 
 import app.revanced.patcher.fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
 
 internal val chapterSeekResultToStringFingerprint = fingerprint {
     parameters()
@@ -12,13 +13,11 @@ internal val chapterSeekResultToStringFingerprint = fingerprint {
 }
 
 internal val chapterSeekResultCtorFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR)
     parameters(
         "Z",
         "Lj\$/time/Duration;",
         "Lj\$/util/Optional;",
         "Z",
     )
-    custom { method, _ ->
-        method.name == "<init>"
-    }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -5,13 +5,7 @@ import app.revanced.patcher.fingerprint
 internal val chapterSeekResultToStringFingerprint = fingerprint {
     parameters()
     returns("Ljava/lang/String;")
-    strings(
-        "ChapterSeekResult{isSeekingToChapterStart=",
-        ", seekDuration=",
-        ", seekText=",
-        ", isOverlayCentered=",
-        "}",
-    )
+    strings("ChapterSeekResult{isSeekingToChapterStart=")
     custom { method, _ ->
         method.name == "toString"
     }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -2,22 +2,30 @@ package app.revanced.patches.youtube.interaction.doubletap
 
 import app.revanced.patcher.fingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
-internal val chapterSeekResultToStringFingerprint = fingerprint {
-    parameters()
-    returns("Ljava/lang/String;")
-    strings("ChapterSeekResult{isSeekingToChapterStart=")
-    custom { method, _ ->
-        method.name == "toString"
+internal val doubleTapInfoGetSeekSourceFingerprint = fingerprint {
+    accessFlags(AccessFlags.PUBLIC, AccessFlags.FINAL)
+    parameters("Z")
+    returns("L")  // enum SeekSource, but name obfuscated
+    opcodes(
+        Opcode.IF_EQZ,
+        Opcode.SGET_OBJECT,
+        Opcode.RETURN_OBJECT,
+        Opcode.SGET_OBJECT,
+        Opcode.RETURN_OBJECT,
+    )
+    custom { _, classDef ->
+        classDef.fields.count() == 4
     }
 }
 
-internal val chapterSeekResultCtorFingerprint = fingerprint {
+internal val doubleTapInfoCtorFingerprint = fingerprint {
     accessFlags(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR)
     parameters(
+        "Landroid/view/MotionEvent;",
+        "I",
         "Z",
-        "Lj\$/time/Duration;",
-        "Lj\$/util/Optional;",
-        "Z",
+        "Lj\$/time/Duration;"
     )
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -12,7 +12,13 @@ internal val chapterSeekResultToStringFingerprint = fingerprint {
 }
 
 internal val chapterSeekResultCtorFingerprint = fingerprint {
+    parameters(
+        "Z",
+        "Lj\$/time/Duration;",
+        "Lj\$/util/Optional;",
+        "Z",
+    )
     custom { method, _ ->
-        method.name == "<init>" && method.parameters.isNotEmpty()
+        method.name == "<init>"
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/interaction/doubletap/Fingerprints.kt
@@ -7,7 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 internal val doubleTapInfoGetSeekSourceFingerprint = fingerprint {
     accessFlags(AccessFlags.PUBLIC, AccessFlags.FINAL)
     parameters("Z")
-    returns("L")  // enum SeekSource, but name obfuscated
+    returns("L")  // Enum SeekSource, but name obfuscated.
     opcodes(
         Opcode.IF_EQZ,
         Opcode.SGET_OBJECT,

--- a/patches/src/main/resources/addresources/values/strings.xml
+++ b/patches/src/main/resources/addresources/values/strings.xml
@@ -516,6 +516,11 @@ This feature is only available for older devices"</string>
             <string name="revanced_remove_viewer_discretion_dialog_summary_off">Dialog will be shown</string>
             <string name="revanced_remove_viewer_discretion_dialog_user_dialog_message">This does not bypass the age restriction. It just accepts it automatically.</string>
         </patch>
+        <patch id="interaction.doubletap.disableChapterSkipDoubleTapPatch">
+            <string name="revanced_disable_chapter_skip_double_tap_title">Disable double tap chapter skip</string>
+            <string name="revanced_disable_chapter_skip_double_tap_summary_on">Double tap can never trigger a skip to the next/previous chapter</string>
+            <string name="revanced_disable_chapter_skip_double_tap_summary_off">Double tap can occasionally trigger a skip to the next/previous chapter</string>
+        </patch>
         <patch id="interaction.downloads.downloadsResourcePatch">
             <string name="revanced_external_downloader_screen_title">External downloads</string>
             <string name="revanced_external_downloader_screen_summary">Settings for using an external downloader</string>


### PR DESCRIPTION
Implements my suggested solution to #5356 . Very bare-bones (no in-app config option, only one verified supported version) because I'm not particularly experienced with ReVanced patches and because it's late at night when I'm writing this and I want to go to sleep.

The patch seems to work, in that I couldn't reproduce the bug on an emulator, however it would've been harder to reproduce on an emulator anyway, so I might've just not tested it enough. I did confirm that jumping to a chapter explicitly through the menu still works, though. The patch is off by default because I suppose some people might want to keep the original skip to chapter gesture.

Any help, improvements or feedback would be appreciated. @oSumAtrIX , since you were the one who reviewed my issue, you might want to review this PR too. (If not, sorry for the ping)