### PR TITLE
fix(Bacon Reader - Spoof client): Use www instead of ssl API to fix auth related issues 

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/baconreader/api/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/reddit/customclients/baconreader/api/SpoofClientPatch.kt
@@ -4,9 +4,16 @@ import app.revanced.patcher.Fingerprint
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.revanced.patches.reddit.customclients.spoofClientPatch
+import app.revanced.patches.shared.misc.string.replaceStringPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 val spoofClientPatch = spoofClientPatch(redirectUri = "http://baconreader.com/auth") { clientIdOption ->
+    dependsOn(
+        // Redirects from SSL to WWW domain are bugged causing auth problems.
+        // Manually rewrite the URLs to fix this.
+        replaceStringPatch("ssl.reddit.com", "www.reddit.com")
+    )
+
     compatibleWith(
         "com.onelouder.baconreader",
         "com.onelouder.baconreader.premium",


### PR DESCRIPTION
Exact same change as #5392 but for Bacon reader discussed in #5387.