### PR TITLE
fix(Twitter - Change Link Sharing Domain): ensure "Share via…" link domain respects options (#4259)

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/twitter/misc/links/Fingerprints.kt
@@ -27,5 +27,11 @@ internal val linkResourceGetterFingerprint = fingerprint {
 }
 
 internal val linkSharingDomainFingerprint = fingerprint {
+    // parameters("JLjava/lang/String;")
+    strings("https://fxtwitter.com")
+}
+
+internal val resourceLinkSharingDomainFingerprint = fingerprint {
+    parameters("[Ljava/lang/Object;")
     strings("https://fxtwitter.com")
 }


### PR DESCRIPTION
Fixes #4259

**Problem**  
Originally only a **single** Fingerprint patched `formatLink`, leaving
`formatResourceLink` untouched. As a result, **Copy link** used the custom
domain in options, while **Share via…** fell back to the hard‑coded string literal
`fxtwitter.com` embedded in the extension.

**Solution**  
Added two dedicated fingerprints:  
* `resourceLinkSharingDomainFingerprint` — matches `formatResourceLink` (Share via…)  
* `linkSharingDomainFingerprint`        — matches `formatLink` (Copy link)

During patching, **the two string literals are patched with the option’s `domainName`,**
so both actions emit links that start with the configured domain.

**Testing**  
Verified on X/Twitter **10.48.0‑release.0**:  
1. Set option `domainName=twitter.com`.  
2. Trigger **Share via…** and **Copy link**.  
3. All generated URLs begin with `https://twitter.com/…`.

No additional dependent PRs.
