### PR TITLE
feat(Tumblr): Disable Tumblr TV patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -1169,6 +1169,10 @@ public final class app/revanced/patches/tumblr/annoyances/popups/DisableGiftMess
 	public static final fun getDisableGiftMessagePopupPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/tumblr/annoyances/tv/DisableTumblrTvPatchKt {
+	public static final fun getDisableTumblrTvPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/tumblr/featureflags/OverrideFeatureFlagsPatchKt {
 	public static final fun getOverrideFeatureFlagsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }

--- a/patches/src/main/kotlin/app/revanced/patches/tumblr/annoyances/tv/DisableTumblrTvPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/tumblr/annoyances/tv/DisableTumblrTvPatch.kt
@@ -1,0 +1,19 @@
+package app.revanced.patches.tumblr.annoyances.tv
+
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patches.tumblr.featureflags.addFeatureFlagOverride
+import app.revanced.patches.tumblr.featureflags.overrideFeatureFlagsPatch
+
+@Suppress("unused")
+val disableTumblrTvPatch = bytecodePatch(
+    name = "Disable Tumblr TV",
+    description = "Removes the Tumblr TV navigation button from the bottom bar",
+) {
+    dependsOn(overrideFeatureFlagsPatch)
+
+    compatibleWith("com.tumblr")
+
+    execute {
+        addFeatureFlagOverride("tumblrTvMobileNav", "false")
+    }
+}


### PR DESCRIPTION
Removes the Tumblr TV button (a commonly hated feature) from the bottom buttons bar

without patch
<img width="510" height="157" alt="image" src="https://github.com/user-attachments/assets/d554e0ec-9f7f-4197-a030-936240715e9d" />

with patch
<img width="510" height="164" alt="image" src="https://github.com/user-attachments/assets/9c959b2a-8764-419a-98f4-3fd51b87e46c" />

