### PR TITLE
feat(Instagram): Add `Sanitize sharing links` patch

### DIFF
--- a/extensions/instagram/build.gradle.kts
+++ b/extensions/instagram/build.gradle.kts
@@ -1,4 +1,3 @@
 dependencies {
-    implementation(project(":extensions:instagram:stub"))
     compileOnly(project(":extensions:shared:library"))
 }

--- a/extensions/instagram/build.gradle.kts
+++ b/extensions/instagram/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
+    implementation(project(":extensions:instagram:stub"))
     compileOnly(project(":extensions:shared:library"))
 }

--- a/extensions/instagram/src/main/java/app/revanced/extension/instagram/misc/privacy/SanitizeSharingLinksPatch.java
+++ b/extensions/instagram/src/main/java/app/revanced/extension/instagram/misc/privacy/SanitizeSharingLinksPatch.java
@@ -1,25 +1,22 @@
 package app.revanced.extension.instagram.misc.privacy;
 
-import android.net.Uri;
-import app.revanced.extension.shared.Logger;
+import app.revanced.extension.shared.privacy.SanitizeSharingLink;
 
 import java.util.List;
 
 @SuppressWarnings("unused")
 public final class SanitizeSharingLinksPatch {
-
     /**
      * Parameters that are considered undesirable and should be stripped away.
      */
     private static final List<String> SHARE_PARAMETERS_TO_REMOVE = List.of(
-            "si", // Share tracking parameter.
-            "utm_source" // Share source, such as "copy-link".
+            "igsh"
     );
 
     /**
      * Injection point.
      */
-    public static void sanitizeUrl(String url, String str2) {
-            Logger.printInfo(() -> "String1 " + url + " String2 " + str2);
+    public static String sanitizeSharingLink(String url) {
+        return SanitizeSharingLink.sanitizeUrl(url, SHARE_PARAMETERS_TO_REMOVE);
     }
 }

--- a/extensions/instagram/src/main/java/app/revanced/extension/instagram/misc/privacy/SanitizeSharingLinksPatch.java
+++ b/extensions/instagram/src/main/java/app/revanced/extension/instagram/misc/privacy/SanitizeSharingLinksPatch.java
@@ -1,0 +1,25 @@
+package app.revanced.extension.instagram.misc.privacy;
+
+import android.net.Uri;
+import app.revanced.extension.shared.Logger;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public final class SanitizeSharingLinksPatch {
+
+    /**
+     * Parameters that are considered undesirable and should be stripped away.
+     */
+    private static final List<String> SHARE_PARAMETERS_TO_REMOVE = List.of(
+            "si", // Share tracking parameter.
+            "utm_source" // Share source, such as "copy-link".
+    );
+
+    /**
+     * Injection point.
+     */
+    public static void sanitizeUrl(String url, String str2) {
+            Logger.printInfo(() -> "String1 " + url + " String2 " + str2);
+    }
+}

--- a/extensions/shared/library/src/main/java/app/revanced/extension/shared/privacy/SanitizeSharingLink.java
+++ b/extensions/shared/library/src/main/java/app/revanced/extension/shared/privacy/SanitizeSharingLink.java
@@ -1,0 +1,30 @@
+package app.revanced.extension.shared.privacy;
+
+import android.net.Uri;
+import app.revanced.extension.shared.Logger;
+
+import java.util.List;
+
+public class SanitizeSharingLink {
+    public static String sanitizeUrl(String url, List<String> shareParameterToRemove) {
+        try {
+            Uri uri = Uri.parse(url);
+            Uri.Builder builder = uri.buildUpon().clearQuery();
+
+            for (String paramName : uri.getQueryParameterNames()) {
+                if (!shareParameterToRemove.contains(paramName)) {
+                    for (String value : uri.getQueryParameters(paramName)) {
+                        builder.appendQueryParameter(paramName, value);
+                    }
+                }
+            }
+
+            String sanitizedUrl = builder.build().toString();
+            Logger.printInfo(() -> "Sanitized url " + url + " to " + sanitizedUrl);
+            return sanitizedUrl;
+        } catch (Exception ex) {
+            Logger.printException(() -> "sanitizeUrl failure with " + url, ex);
+            return url;
+        }
+    }
+}

--- a/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/privacy/SanitizeSharingLinksPatch.java
+++ b/extensions/spotify/src/main/java/app/revanced/extension/spotify/misc/privacy/SanitizeSharingLinksPatch.java
@@ -1,10 +1,8 @@
 package app.revanced.extension.spotify.misc.privacy;
 
-import android.net.Uri;
-
 import java.util.List;
 
-import app.revanced.extension.shared.Logger;
+import app.revanced.extension.shared.privacy.SanitizeSharingLink;
 
 @SuppressWarnings("unused")
 public final class SanitizeSharingLinksPatch {
@@ -20,25 +18,7 @@ public final class SanitizeSharingLinksPatch {
     /**
      * Injection point.
      */
-    public static String sanitizeUrl(String url) {
-        try {
-            Uri uri = Uri.parse(url);
-            Uri.Builder builder = uri.buildUpon().clearQuery();
-
-            for (String paramName : uri.getQueryParameterNames()) {
-                if (!SHARE_PARAMETERS_TO_REMOVE.contains(paramName)) {
-                    for (String value : uri.getQueryParameters(paramName)) {
-                        builder.appendQueryParameter(paramName, value);
-                    }
-                }
-            }
-
-            String sanitizedUrl = builder.build().toString();
-            Logger.printInfo(() -> "Sanitized url " + url + " to " + sanitizedUrl);
-            return sanitizedUrl;
-        } catch (Exception ex) {
-            Logger.printException(() -> "sanitizeUrl failure with " + url, ex);
-            return url;
-        }
+    public static String sanitizeSharingLink(String url) {
+        return SanitizeSharingLink.sanitizeUrl(url, SHARE_PARAMETERS_TO_REMOVE);
     }
 }

--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -284,6 +284,10 @@ public final class app/revanced/patches/instagram/misc/extension/SharedExtension
 	public static final fun getSharedExtensionPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class app/revanced/patches/instagram/misc/privacy/SanitizeSharingLinksPatchKt {
+	public static final fun getSanitizeSharingLinksPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class app/revanced/patches/instagram/misc/signature/SignatureCheckPatchKt {
 	public static final fun getSignatureCheckPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
@@ -802,6 +806,10 @@ public final class app/revanced/patches/shared/misc/mapping/ResourceMappingPatch
 
 public final class app/revanced/patches/shared/misc/pairip/license/DisableLicenseCheckPatchKt {
 	public static final fun getDisableLicenseCheckPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
+public final class app/revanced/patches/shared/misc/privacy/SanitizeSharingLinkPatchKt {
+	public static final fun sanitizeSharingLinkPatch (Lapp/revanced/patcher/Fingerprint;II)Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
 public final class app/revanced/patches/shared/misc/settings/SettingsPatchKt {

--- a/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/Fingerprints.kt
@@ -1,13 +1,8 @@
 package app.revanced.patches.instagram.misc.privacy
 
 import app.revanced.patcher.fingerprint
-import app.revanced.util.literal
-import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
-internal val testFingerprint = fingerprint {
-    custom { method, classDef ->
-        method.name == "A00" &&
-                classDef.type == "LX/Hk9;"
-    }
+internal val permalinkResponseJsonParserFingerprint = fingerprint {
+    strings("permalink", "PermalinkResponse")
+    custom { method, _ -> method.name == "parseFromJson" }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/Fingerprints.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.instagram.misc.privacy
+
+import app.revanced.patcher.fingerprint
+import app.revanced.util.literal
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal val testFingerprint = fingerprint {
+    custom { method, classDef ->
+        method.name == "A00" &&
+                classDef.type == "LX/Hk9;"
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/instagram/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -1,0 +1,27 @@
+package app.revanced.patches.instagram.misc.privacy
+
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patches.instagram.misc.extension.sharedExtensionPatch
+
+private const val EXTENSION_CLASS_DESCRIPTOR =
+    "Lapp/revanced/extension/instagram/misc/privacy/SanitizeSharingLinksPatch;"
+
+@Suppress("unused")
+val sanitizeSharingLinksPatch = bytecodePatch(
+    name = "Sanitize sharing links",
+    description = "Removes the tracking query parameters from links before they are shared.",
+) {
+    compatibleWith("com.instagram.android")
+
+    dependsOn(sharedExtensionPatch)
+
+    execute {
+        val extensionMethodDescriptor = "$EXTENSION_CLASS_DESCRIPTOR->" +
+                "sanitizeUrl(Ljava/lang/String;)V"
+
+        testFingerprint.method.addInstruction(0,
+            "invoke-static/range { p0 .. p1 }, $extensionMethodDescriptor"
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/patches/spotify/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/spotify/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -24,7 +24,7 @@ val sanitizeSharingLinksPatch = bytecodePatch(
 
     execute {
         val extensionMethodDescriptor = "$EXTENSION_CLASS_DESCRIPTOR->" +
-                "sanitizeUrl(Ljava/lang/String;)Ljava/lang/String;"
+                "sanitizeSharingLink(Ljava/lang/String;)Ljava/lang/String;"
 
         val copyFingerprint = if (shareCopyUrlFingerprint.originalMethodOrNull != null) {
             shareCopyUrlFingerprint


### PR DESCRIPTION
Abstracted the extension method to sanitize links into the shared library, so it can be reused. Applied this new method for both Instagram and Spotify.

Closes https://github.com/ReVanced/revanced-patches/issues/4124.